### PR TITLE
Return the cached value if it's not time to scan again yet

### DIFF
--- a/readjson.go
+++ b/readjson.go
@@ -76,12 +76,7 @@ func readData(device string) (gjson.Result, error) {
 
 	if _, err := os.Stat(device); err == nil {
 		cacheValue, cacheOk := jsonCache[device]
-		timeToScan := false
-		if cacheOk {
-			timeToScan = time.Now().After(cacheValue.LastCollect.Add(options.SMARTctl.CollectPeriodDuration))
-		}
-
-		if timeToScan || !cacheOk {
+		if !cacheOk || time.Now().After(cacheValue.LastCollect.Add(options.SMARTctl.CollectPeriodDuration)) {
 			json, ok := readSMARTctl(device)
 			if ok {
 				jsonCache[device] = JSONCache{JSON: json, LastCollect: time.Now()}

--- a/readjson.go
+++ b/readjson.go
@@ -79,11 +79,9 @@ func readData(device string) (gjson.Result, error) {
 		timeToScan := false
 		if cacheOk {
 			timeToScan = time.Now().After(cacheValue.LastCollect.Add(options.SMARTctl.CollectPeriodDuration))
-		} else {
-			timeToScan = true
 		}
 
-		if timeToScan {
+		if timeToScan || !cacheOk {
 			json, ok := readSMARTctl(device)
 			if ok {
 				jsonCache[device] = JSONCache{JSON: json, LastCollect: time.Now()}
@@ -91,7 +89,7 @@ func readData(device string) (gjson.Result, error) {
 			}
 			return gjson.Parse("{}"), fmt.Errorf("smartctl returned bad data for device %s", device)
 		}
-		return gjson.Parse("{}"), fmt.Errorf("Too early collect called for device %s", device)
+		return cacheValue.JSON, nil
 	}
 	return gjson.Parse("{}"), fmt.Errorf("Device %s unavialable", device)
 }


### PR DESCRIPTION
This fixes #13: Since we have a value cached, we should return it to the collector if it gets queried before the interval to re-scan SMART data expires. This prevents the crash.