### PR TITLE
Remove armv7 container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 armv7 arm64
+DOCKER_ARCHS ?= amd64 arm64
 DOCKER_REPO  ?= prometheuscommunity
 
 include Makefile.common


### PR DESCRIPTION
Alpine's naming for armv7 doesn't match.

Signed-off-by: SuperQ <superq@gmail.com>