### PR TITLE
Fix up multi-platform container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM ${ARCH}/alpine:3
+FROM --platform ${OS}/${ARCH} alpine:3
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 RUN apk add smartmontools


### PR DESCRIPTION
Use the `--platform` flag on `FROM` to build with the correct platform.

Signed-off-by: SuperQ <superq@gmail.com>