### PR TITLE
Drop arm64 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM --platform ${OS}/${ARCH} alpine:3
+FROM alpine:3
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 RUN apk add smartmontools

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 arm64
+DOCKER_ARCHS ?= amd64
 DOCKER_REPO  ?= prometheuscommunity
 
 include Makefile.common


### PR DESCRIPTION
Drop the arm64 Docker image until we figure out a good cross-build setup for alpine-based builds.

Fixes: https://github.com/prometheus-community/smartctl_exporter/issues/78

Signed-off-by: SuperQ <superq@gmail.com>