### PR TITLE
Removed doubled NVMe metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -289,31 +289,9 @@ var (
 		},
 		nil,
 	)
-	metricCriticalWarning = prometheus.NewDesc(
-		"critical_warning",
-		"Critical warning counter",
-		[]string{
-			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
-		},
-		nil,
-	)
 	metricDeviceStatus = prometheus.NewDesc(
 		"smartctl_device_status",
 		"Device status",
-		[]string{
-			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
-		},
-		nil,
-	)
-	metricAvailableSpare = prometheus.NewDesc(
-		"available_spare",
-		"Available spare",
 		[]string{
 			"device",
 			"model_family",
@@ -334,17 +312,6 @@ var (
 		},
 		nil,
 	)
-	metricMediaErrors = prometheus.NewDesc(
-		"media_errors",
-		"Media errors counter",
-		[]string{
-			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
-		},
-		nil,
-	)
 	metricDeviceSelfTestLogCount = prometheus.NewDesc(
 		"smartctl_device_self_test_log_count",
 		"Device SMART self test log count",
@@ -354,17 +321,6 @@ var (
 			"model_name",
 			"serial_number",
 			"self_test_log_type",
-		},
-		nil,
-	)
-	metricSmartStatus = prometheus.NewDesc(
-		"smart_status",
-		"Smart status",
-		[]string{
-			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)

--- a/smartctl.go
+++ b/smartctl.go
@@ -68,8 +68,6 @@ func (smart *SMARTctl) Collect() {
 	smart.minePowerCycleCount()
 	smart.mineDeviceSCTStatus()
 	smart.mineDeviceStatistics()
-	smart.mineNvmeSmartHealthInformationLog()
-	smart.mineNvmeSmartStatus()
 	smart.mineDeviceStatus()
 	smart.mineDeviceErrorLog()
 	smart.mineDeviceSelfTestLog()
@@ -442,56 +440,12 @@ func (smart *SMARTctl) mineLongFlags(json gjson.Result, flags []string) string {
 	return strings.Join(result, ",")
 }
 
-func (smart *SMARTctl) mineNvmeSmartHealthInformationLog() {
-	iHealth := smart.json.Get("nvme_smart_health_information_log")
-	smart.ch <- prometheus.MustNewConstMetric(
-		metricCriticalWarning,
-		prometheus.GaugeValue,
-		iHealth.Get("critical_warning").Float(),
-		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
-	)
-	smart.ch <- prometheus.MustNewConstMetric(
-		metricAvailableSpare,
-		prometheus.GaugeValue,
-		iHealth.Get("available_spare").Float(),
-		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
-	)
-	smart.ch <- prometheus.MustNewConstMetric(
-		metricMediaErrors,
-		prometheus.GaugeValue,
-		iHealth.Get("media_errors").Float(),
-		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
-	)
-}
-
 func (smart *SMARTctl) mineDeviceStatus() {
 	status := smart.json.Get("smart_status")
 	smart.ch <- prometheus.MustNewConstMetric(
 		metricDeviceStatus,
 		prometheus.GaugeValue,
 		status.Get("passed").Float(),
-		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
-	)
-}
-
-func (smart *SMARTctl) mineNvmeSmartStatus() {
-	iStatus := smart.json.Get("smart_status")
-	smart.ch <- prometheus.MustNewConstMetric(
-		metricSmartStatus,
-		prometheus.GaugeValue,
-		iStatus.Get("passed").Float(),
 		smart.device.device,
 		smart.device.family,
 		smart.device.model,


### PR DESCRIPTION
During tests find out some NVMe-related metrics are double. Removed metrics without prefix

![image](https://user-images.githubusercontent.com/7759548/195596433-eedcada2-75f1-4fee-ba50-213c863839bf.png)
