### PR TITLE
Reduced number of meta labels

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -51,9 +51,6 @@ var (
 		"Device capacity in blocks",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -62,9 +59,6 @@ var (
 		"Device capacity in bytes",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -73,9 +67,6 @@ var (
 		"Device block size",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"blocks_type",
 		},
 		nil,
@@ -85,9 +76,6 @@ var (
 		"Device interface speed, bits per second",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"speed_type",
 		},
 		nil,
@@ -97,9 +85,6 @@ var (
 		"Device attributes",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"attribute_name",
 			"attribute_flags_short",
 			"attribute_flags_long",
@@ -113,9 +98,6 @@ var (
 		"Device power on seconds",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -124,9 +106,6 @@ var (
 		"Device rotation rate",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -135,9 +114,6 @@ var (
 		"Device temperature celsius",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"temperature_type",
 		},
 		nil,
@@ -147,9 +123,6 @@ var (
 		"Device power cycle count",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -158,9 +131,6 @@ var (
 		"Device write percentage used",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -169,9 +139,6 @@ var (
 		"Normalized percentage (0 to 100%) of the remaining spare capacity available",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -180,9 +147,6 @@ var (
 		"When the Available Spare falls below the threshold indicated in this field, an asynchronous event completion may occur. The value is indicated as a normalized percentage (0 to 100%)",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -191,9 +155,6 @@ var (
 		"This field indicates critical warnings for the state of the controller",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -202,9 +163,6 @@ var (
 		"Contains the number of occurrences where the controller detected an unrecovered data integrity error. Errors such as uncorrectable ECC, CRC checksum failure, or LBA tag mismatch are included in this field",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -213,9 +171,6 @@ var (
 		"Contains the number of Error Information log entries over the life of the controller",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -224,9 +179,6 @@ var (
 		"",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -235,9 +187,6 @@ var (
 		"",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -246,9 +195,6 @@ var (
 		"General smart status",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -257,9 +203,6 @@ var (
 		"Exit status of smartctl on device",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -268,9 +211,6 @@ var (
 		"Device state (0=active, 1=standby, 2=sleep, 3=dst, 4=offline, 5=sct)",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -279,9 +219,6 @@ var (
 		"Device statistics",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"statistic_table",
 			"statistic_name",
 			"statistic_flags_short",
@@ -294,9 +231,6 @@ var (
 		"Device status",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -305,9 +239,6 @@ var (
 		"Device SMART error log count",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"error_log_type",
 		},
 		nil,
@@ -317,9 +248,6 @@ var (
 		"Device SMART self test log count",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"self_test_log_type",
 		},
 		nil,
@@ -329,9 +257,6 @@ var (
 		"Device SMART self test log error count",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"self_test_log_type",
 		},
 		nil,
@@ -341,9 +266,6 @@ var (
 		"Device SMART Error Recovery Control Seconds",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 			"op_type",
 		},
 		nil,

--- a/smartctl.go
+++ b/smartctl.go
@@ -90,9 +90,6 @@ func (smart *SMARTctl) mineExitStatus() {
 		prometheus.GaugeValue,
 		smart.json.Get("smartctl.exit_status").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -122,18 +119,12 @@ func (smart *SMARTctl) mineCapacity() {
 		prometheus.GaugeValue,
 		capacity.Get("blocks").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 	smart.ch <- prometheus.MustNewConstMetric(
 		metricDeviceCapacityBytes,
 		prometheus.GaugeValue,
 		capacity.Get("bytes").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 	for _, blockType := range []string{"logical", "physical"} {
 		smart.ch <- prometheus.MustNewConstMetric(
@@ -141,9 +132,6 @@ func (smart *SMARTctl) mineCapacity() {
 			prometheus.GaugeValue,
 			smart.json.Get(fmt.Sprintf("%s_block_size", blockType)).Float(),
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 			blockType,
 		)
 	}
@@ -158,9 +146,6 @@ func (smart *SMARTctl) mineInterfaceSpeed() {
 			prometheus.GaugeValue,
 			tSpeed.Get("units_per_second").Float()*tSpeed.Get("bits_per_unit").Float(),
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 			speedType,
 		)
 	}
@@ -190,9 +175,6 @@ func (smart *SMARTctl) mineDeviceAttribute() {
 				prometheus.GaugeValue,
 				attribute.Get(path).Float(),
 				smart.device.device,
-				smart.device.family,
-				smart.device.model,
-				smart.device.serial,
 				name,
 				flagsShort,
 				flagsLong,
@@ -210,9 +192,6 @@ func (smart *SMARTctl) minePowerOnSeconds() {
 		prometheus.CounterValue,
 		GetFloatIfExists(pot, "hours", 0)*60*60+GetFloatIfExists(pot, "minutes", 0)*60,
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -224,9 +203,6 @@ func (smart *SMARTctl) mineRotationRate() {
 			prometheus.GaugeValue,
 			rRate,
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 		)
 	}
 }
@@ -240,9 +216,6 @@ func (smart *SMARTctl) mineTemperatures() {
 				prometheus.GaugeValue,
 				value.Float(),
 				smart.device.device,
-				smart.device.family,
-				smart.device.model,
-				smart.device.serial,
 				key.String(),
 			)
 			return true
@@ -256,9 +229,6 @@ func (smart *SMARTctl) minePowerCycleCount() {
 		prometheus.CounterValue,
 		smart.json.Get("power_cycle_count").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -270,9 +240,6 @@ func (smart *SMARTctl) mineDeviceSCTStatus() {
 			prometheus.GaugeValue,
 			status.Get("device_state").Float(),
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 		)
 	}
 }
@@ -283,9 +250,6 @@ func (smart *SMARTctl) minePercentageUsed() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.percentage_used").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -295,9 +259,6 @@ func (smart *SMARTctl) mineAvailableSpare() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.available_spare").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -307,9 +268,6 @@ func (smart *SMARTctl) mineAvailableSpareThreshold() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.available_spare_threshold").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -319,9 +277,6 @@ func (smart *SMARTctl) mineCriticalWarning() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.critical_warning").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -331,9 +286,6 @@ func (smart *SMARTctl) mineMediaErrors() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.media_errors").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -343,9 +295,6 @@ func (smart *SMARTctl) mineNumErrLogEntries() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.num_err_log_entries").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -356,9 +305,6 @@ func (smart *SMARTctl) mineBytesRead() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.data_units_read").Float()*blockSize,
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -369,9 +315,6 @@ func (smart *SMARTctl) mineBytesWritten() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.data_units_written").Float()*blockSize,
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -381,9 +324,6 @@ func (smart *SMARTctl) mineSmartStatus() {
 		prometheus.GaugeValue,
 		smart.json.Get("smart_status.passed").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -418,9 +358,6 @@ func (smart *SMARTctl) mineDeviceStatistics() {
 			prometheus.GaugeValue,
 			statistic.Get("value").Float(),
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 			"SATA PHY Event Counters",
 			strings.TrimSpace(statistic.Get("name").String()),
 			"V---",
@@ -447,9 +384,6 @@ func (smart *SMARTctl) mineDeviceStatus() {
 		prometheus.GaugeValue,
 		status.Get("passed").Float(),
 		smart.device.device,
-		smart.device.family,
-		smart.device.model,
-		smart.device.serial,
 	)
 }
 
@@ -460,9 +394,6 @@ func (smart *SMARTctl) mineDeviceErrorLog() {
 			prometheus.GaugeValue,
 			status.Get("count").Float(),
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 			logType,
 		)
 	}
@@ -475,9 +406,6 @@ func (smart *SMARTctl) mineDeviceSelfTestLog() {
 			prometheus.GaugeValue,
 			status.Get("count").Float(),
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 			logType,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
@@ -485,9 +413,6 @@ func (smart *SMARTctl) mineDeviceSelfTestLog() {
 			prometheus.GaugeValue,
 			status.Get("error_count_total").Float(),
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 			logType,
 		)
 	}
@@ -500,9 +425,6 @@ func (smart *SMARTctl) mineDeviceERC() {
 			prometheus.GaugeValue,
 			status.Get("deciseconds").Float()/10.0,
 			smart.device.device,
-			smart.device.family,
-			smart.device.model,
-			smart.device.serial,
 			ercType,
 		)
 	}


### PR DESCRIPTION
On test stand with 5 disks data size from exporter reduced from **148KB** to **82KB**

Meta labels for alerting & dashboards can be joined by `device` label from `smartctl_device` metric

Resolves #71 