### PR TITLE
Pruned /dev/ prefix from device label

### DIFF
--- a/smartctl.go
+++ b/smartctl.go
@@ -46,7 +46,7 @@ func NewSMARTctl(logger log.Logger, json gjson.Result, ch chan<- prometheus.Metr
 		json:   json,
 		logger: logger,
 		device: SMARTDevice{
-			device: strings.TrimSpace(json.Get("device.name").String()),
+			device: strings.TrimPrefix(strings.TrimSpace(json.Get("device.name").String()), "/dev/"),
 			serial: strings.TrimSpace(json.Get("serial_number").String()),
 			family: strings.TrimSpace(json.Get("model_family").String()),
 			model:  strings.TrimSpace(json.Get("model_name").String()),


### PR DESCRIPTION
Now label matched with `node_exporter` labels
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/7759548/196118783-8d875d4f-46d7-4de9-8d3c-f89db58a3b72.png">
