### PR TITLE
Add device type support

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,9 @@ var (
 	smartctlInterval = kingpin.Flag("smartctl.interval",
 		"The interval between smarctl polls",
 	).Default("60s").Duration()
+	smartctlDeviceType = kingpin.Flag("smartctl.device-type",
+		"The device type (-d / --device)",
+	).Default("auto").String()
 	smartctlDevices = kingpin.Flag("smartctl.device",
 		"The device to monitor (repeatable)",
 	).Strings()


### PR DESCRIPTION
Allow passing a custom `-d` / `--device=` flag to smartctl. The default is the same (`auto`) as upstream smartctl.

Fixes: https://github.com/prometheus-community/smartctl_exporter/issues/26

Signed-off-by: SuperQ <superq@gmail.com>