### PR TITLE
Add counter for the number of devices configured or dynamically discovered

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,11 @@ func (i SMARTctlManagerCollector) Collect(ch chan<- prometheus.Metric) {
 			smart.Collect()
 		}
 	}
+	ch <- prometheus.MustNewConstMetric(
+		metricDeviceCount,
+		prometheus.GaugeValue,
+		float64(len(i.Devices)),
+	)
 	info.Collect()
 }
 
@@ -123,11 +128,7 @@ func main() {
 	} else {
 		level.Info(logger).Log("msg", "No devices specified, trying to load them automatically")
 		devices = scanDevices(logger)
-	}
-
-	if len(devices) == 0 {
-		level.Error(logger).Log("msg", "No devices found")
-		os.Exit(1)
+		level.Info(logger).Log("msg", "Number of devices found", "count", len(devices))
 	}
 
 	collector := SMARTctlManagerCollector{

--- a/metrics.go
+++ b/metrics.go
@@ -47,6 +47,12 @@ var (
 		},
 		nil,
 	)
+	metricDeviceCount = prometheus.NewDesc(
+		"smartctl_device_count",
+		"Number of devices configured or dynamically discovered",
+		[]string{},
+		nil,
+	)
 	metricDeviceCapacityBlocks = prometheus.NewDesc(
 		"smartctl_device_capacity_blocks",
 		"Device capacity in blocks",


### PR DESCRIPTION
This PR will add a counter to the exporter which represents the number of devices either configured or dynamically discovered.

In addition this PR removes the code that the exporter will exit if no devices are configured and no devices are found during the scan.

Fixes #128 