### PR TITLE
Critical metrics for SCSI disks added, rebased

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -271,4 +271,59 @@ var (
 		},
 		nil,
 	)
+	metricSCSIGrownDefectList = prometheus.NewDesc(
+		"smartctl_scsi_grown_defect_list",
+		"Device SCSI grown defect list counter",
+		[]string{
+			"device",
+			"model_family",
+			"model_name",
+			"serial_number",
+		},
+		nil,
+	)
+	metricReadErrorsCorrectedByRereadsRewrites = prometheus.NewDesc(
+		"smartctl_read_errors_corrected_by_rereads_rewrites",
+		"Read Errors Corrected by ReReads/ReWrites",
+		[]string{
+			"device",
+			"model_family",
+			"model_name",
+			"serial_number",
+		},
+		nil,
+	)
+	metricReadTotalUncorrectedErrors = prometheus.NewDesc(
+		"smartctl_read_total_uncorrected_errors",
+		"Read Total Uncorrected Errors",
+		[]string{
+			"device",
+			"model_family",
+			"model_name",
+			"serial_number",
+		},
+		nil,
+	)
+	metricWriteErrorsCorrectedByRereadsRewrites = prometheus.NewDesc(
+		"smartctl_write_errors_corrected_by_rereads_rewrites",
+		"Write Errors Corrected by ReReads/ReWrites",
+		[]string{
+			"device",
+			"model_family",
+			"model_name",
+			"serial_number",
+		},
+		nil,
+	)
+	metricWriteTotalUncorrectedErrors = prometheus.NewDesc(
+		"smartctl_write_total_uncorrected_errors",
+		"Write Total Uncorrected Errors",
+		[]string{
+			"device",
+			"model_family",
+			"model_name",
+			"serial_number",
+		},
+		nil,
+	)
 )

--- a/readjson.go
+++ b/readjson.go
@@ -64,7 +64,7 @@ func readFakeSMARTctl(logger log.Logger, device string) gjson.Result {
 // Get json from smartctl and parse it
 func readSMARTctl(logger log.Logger, device string) (gjson.Result, bool) {
 	level.Debug(logger).Log("msg", "Collecting S.M.A.R.T. counters", "device", device)
-	out, err := exec.Command(*smartctlPath, "--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", device).Output()
+	out, err := exec.Command(*smartctlPath, "--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", "--log=error", device).Output()
 	if err != nil {
 		level.Warn(logger).Log("msg", "S.M.A.R.T. output reading", "err", err)
 	}

--- a/smartctl.go
+++ b/smartctl.go
@@ -81,7 +81,8 @@ func (smart *SMARTctl) Collect() {
 	smart.mineBytesRead()
 	smart.mineBytesWritten()
 	smart.mineSmartStatus()
-
+	smart.mineSCSIGrownDefectList()
+	smart.mineSCSIErrorCounterLog()
 }
 
 func (smart *SMARTctl) mineExitStatus() {
@@ -432,6 +433,63 @@ func (smart *SMARTctl) mineDeviceERC() {
 			status.Get("deciseconds").Float()/10.0,
 			smart.device.device,
 			ercType,
+		)
+	}
+}
+
+func (smart *SMARTctl) mineSCSIGrownDefectList() {
+	scsi_grown_defect_list := smart.json.Get("scsi_grown_defect_list")
+	if scsi_grown_defect_list.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricSCSIGrownDefectList,
+			prometheus.CounterValue,
+			scsi_grown_defect_list.Float(),
+			smart.device.device,
+			smart.device.family,
+			smart.device.model,
+			smart.device.serial,
+		)
+	}
+}
+
+func (smart *SMARTctl) mineSCSIErrorCounterLog() {
+	SCSIHealth := smart.json.Get("scsi_error_counter_log")
+	if SCSIHealth.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricReadErrorsCorrectedByRereadsRewrites,
+			prometheus.CounterValue,
+			SCSIHealth.Get("read.errors_corrected_by_rereads_rewrites").Float(),
+			smart.device.device,
+			smart.device.family,
+			smart.device.model,
+			smart.device.serial,
+		)
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricReadTotalUncorrectedErrors,
+			prometheus.CounterValue,
+			SCSIHealth.Get("read.total_uncorrected_errors").Float(),
+			smart.device.device,
+			smart.device.family,
+			smart.device.model,
+			smart.device.serial,
+		)
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricWriteErrorsCorrectedByRereadsRewrites,
+			prometheus.CounterValue,
+			SCSIHealth.Get("write.errors_corrected_by_rereads_rewrites").Float(),
+			smart.device.device,
+			smart.device.family,
+			smart.device.model,
+			smart.device.serial,
+		)
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricWriteTotalUncorrectedErrors,
+			prometheus.CounterValue,
+			SCSIHealth.Get("write.total_uncorrected_errors").Float(),
+			smart.device.device,
+			smart.device.family,
+			smart.device.model,
+			smart.device.serial,
 		)
 	}
 }

--- a/smartctl.go
+++ b/smartctl.go
@@ -442,7 +442,7 @@ func (smart *SMARTctl) mineSCSIGrownDefectList() {
 	if scsi_grown_defect_list.Exists() {
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricSCSIGrownDefectList,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			scsi_grown_defect_list.Float(),
 			smart.device.device,
 			smart.device.family,
@@ -457,7 +457,7 @@ func (smart *SMARTctl) mineSCSIErrorCounterLog() {
 	if SCSIHealth.Exists() {
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricReadErrorsCorrectedByRereadsRewrites,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			SCSIHealth.Get("read.errors_corrected_by_rereads_rewrites").Float(),
 			smart.device.device,
 			smart.device.family,
@@ -466,7 +466,7 @@ func (smart *SMARTctl) mineSCSIErrorCounterLog() {
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricReadTotalUncorrectedErrors,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			SCSIHealth.Get("read.total_uncorrected_errors").Float(),
 			smart.device.device,
 			smart.device.family,
@@ -475,7 +475,7 @@ func (smart *SMARTctl) mineSCSIErrorCounterLog() {
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricWriteErrorsCorrectedByRereadsRewrites,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			SCSIHealth.Get("write.errors_corrected_by_rereads_rewrites").Float(),
 			smart.device.device,
 			smart.device.family,
@@ -484,7 +484,7 @@ func (smart *SMARTctl) mineSCSIErrorCounterLog() {
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricWriteTotalUncorrectedErrors,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			SCSIHealth.Get("write.total_uncorrected_errors").Float(),
 			smart.device.device,
 			smart.device.family,


### PR DESCRIPTION
This is a rebase of PR #21 against master, with all credit going to @wwwlde.

- Changes CounterValue to GaugeValue as requested
- Adds  `--log=error` in smartctl arguments to include SCSI error counters