### PR TITLE
Example of running with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,18 @@ This exporter supports TLS and basic authentication.
 To use TLS and/or basic authentication, you need to pass a configuration file
 using the `--web.config.file` parameter. The format of the file is described
 [in the exporter-toolkit repository](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md).
+
+## Example of running in Docker
+
+Minimal functional `docker-compose.yml`:
+```yaml
+version: "3"
+
+services:
+  smartctl-exporter:
+    image: prometheuscommunity/smartctl-exporter
+    privileged: true
+    user: root
+    ports:
+      - "9633:9633"
+```


### PR DESCRIPTION
I'm fairly certain it is possible to avoid `privileged: true` at least with explicit capabilities, but this will get users started.

Related to https://github.com/prometheus-community/smartctl_exporter/issues/9, though I'm not sure it resolves it since this is just for Docker.