### PR TITLE
Systemd file with RuntimeMaxSec (auto-restart feature)

### DIFF
--- a/systemd/smartctl_exporter.service
+++ b/systemd/smartctl_exporter.service
@@ -1,19 +1,13 @@
 [Unit]
-Description=smartctl exporter service
-After=network-online.target
+Description=Prometheus smartctl exporter
+After=network.target
 
 [Service]
-Type=simple
-PIDFile=/run/smartctl_exporter.pid
 ExecStart=/usr/bin/smartctl_exporter
+RuntimeMaxSec=1h
+Restart=always
 User=root
 Group=root
-SyslogIdentifier=smartctl_exporter
-Restart=on-failure
-RemainAfterExit=no
-RestartSec=100ms
-StandardOutput=journal
-StandardError=journal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added option that restarts service for every hour, due lack of auto rescan for new/changed devices after exporter run

Partly resolves https://github.com/prometheus-community/smartctl_exporter/issues/130

Test:
```
Jul 29 15:49:45 k0ste.ru systemd[1]: Started Prometheus smartctl exporter.
Jul 29 15:49:45 k0ste.ru smartctl_exporter[324064]: ts=2023-07-29T08:49:45.012Z caller=main.go:90 level=info msg="Starting smartctl_exporter" version="(version=0.9.1, branch=master, revision=54bc9980c2075b664058b6fc36cab91a1d523c59)"
Jul 29 15:49:45 k0ste.ru smartctl_exporter[324064]: ts=2023-07-29T08:49:45.012Z caller=main.go:91 level=info msg="Build context" build_context="(go=go1.20.6, user=k0ste@k0ste.ru, date=20230729-15:47:37)"
Jul 29 15:49:45 k0ste.ru smartctl_exporter[324064]: ts=2023-07-29T08:49:45.027Z caller=main.go:119 level=info msg="No devices specified, trying to load them automatically"
Jul 29 15:49:45 k0ste.ru smartctl_exporter[324064]: ts=2023-07-29T08:49:45.257Z caller=tls_config.go:232 level=info msg="Listening on" address=[::]:9633
Jul 29 15:49:45 k0ste.ru smartctl_exporter[324064]: ts=2023-07-29T08:49:45.257Z caller=tls_config.go:235 level=info msg="TLS is disabled." http2=false address=[::]:9633
Jul 29 16:49:45 k0ste.ru systemd[1]: smartctl_exporter.service: Service reached runtime time limit. Stopping.
Jul 29 16:49:45 k0ste.ru systemd[1]: smartctl_exporter.service: Failed with result 'timeout'.
Jul 29 16:49:45 k0ste.ru systemd[1]: smartctl_exporter.service: Scheduled restart job, restart counter is at 1.
Jul 29 16:49:45 k0ste.ru systemd[1]: Stopped Prometheus smartctl exporter.
Jul 29 16:49:45 k0ste.ru systemd[1]: Started Prometheus smartctl exporter.
Jul 29 16:49:45 k0ste.ru smartctl_exporter[333687]: ts=2023-07-29T09:49:45.337Z caller=main.go:90 level=info msg="Starting smartctl_exporter" version="(version=0.9.1, branch=master, revision=54bc9980c2075b664058b6fc36cab91a1d523c59)"
Jul 29 16:49:45 k0ste.ru smartctl_exporter[333687]: ts=2023-07-29T09:49:45.337Z caller=main.go:91 level=info msg="Build context" build_context="(go=go1.20.6, user=k0ste@k0ste.ru, date=20230729-15:47:37)"
Jul 29 16:49:45 k0ste.ru smartctl_exporter[333687]: ts=2023-07-29T09:49:45.352Z caller=main.go:119 level=info msg="No devices specified, trying to load them automatically"
Jul 29 16:49:45 k0ste.ru smartctl_exporter[333687]: ts=2023-07-29T09:49:45.588Z caller=tls_config.go:232 level=info msg="Listening on" address=[::]:9633
Jul 29 16:49:45 k0ste.ru smartctl_exporter[333687]: ts=2023-07-29T09:49:45.588Z caller=tls_config.go:235 level=info msg="TLS is disabled." http2=false address=[::]:9633
```