### PR TITLE
Add background scanning for devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Flags:
       --smartctl.path="/usr/sbin/smartctl"  
                                The path to the smartctl binary
       --smartctl.interval=60s  The interval between smartctl polls
+      --smartctl.rescan=10m    The interval between rescanning for new/disappeared devices. If the interval is smaller than 1s no
+                               rescanning takes place. If any devices are configured with smartctl.device also no rescanning takes
+                               place.
       --smartctl.device=SMARTCTL.DEVICE ...  
                                The device to monitor (repeatable)
       --smartctl.device-exclude=""


### PR DESCRIPTION
Add a background routine to rescan in a specified interval for devices

By default the rescanning is triggered every 10 minutes. Please let me know if this interval is too short or too long or if the rescanning should be disabled by default. This can be done by setting the rescan interval to less than 1 seconds.

Fixes #130 