### PR TITLE
Added device name to logger rc code parser

### DIFF
--- a/readjson.go
+++ b/readjson.go
@@ -66,10 +66,10 @@ func readSMARTctl(logger log.Logger, device string) (gjson.Result, bool) {
 	level.Debug(logger).Log("msg", "Collecting S.M.A.R.T. counters", "device", device)
 	out, err := exec.Command(*smartctlPath, "--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", device).Output()
 	if err != nil {
-		level.Warn(logger).Log("msg", "S.M.A.R.T. output reading", "err", err)
+		level.Warn(logger).Log("msg", "S.M.A.R.T. output reading", "err", err, "device", device)
 	}
 	json := parseJSON(string(out))
-	rcOk := resultCodeIsOk(logger, json.Get("smartctl.exit_status").Int())
+	rcOk := resultCodeIsOk(logger, device, json.Get("smartctl.exit_status").Int())
 	jsonOk := jsonIsOk(logger, json)
 	return json, rcOk && jsonOk
 }
@@ -111,35 +111,35 @@ func readData(logger log.Logger, device string) gjson.Result {
 }
 
 // Parse smartctl return code
-func resultCodeIsOk(logger log.Logger, SMARTCtlResult int64) bool {
+func resultCodeIsOk(logger log.Logger, device string, SMARTCtlResult int64) bool {
 	result := true
 	if SMARTCtlResult > 0 {
 		b := SMARTCtlResult
 		if (b & 1) != 0 {
-			level.Error(logger).Log("msg", "Command line did not parse.")
+			level.Error(logger).Log("msg", "Command line did not parse", "device", device)
 			result = false
 		}
 		if (b & (1 << 1)) != 0 {
-			level.Error(logger).Log("msg", "Device open failed, device did not return an IDENTIFY DEVICE structure, or device is in a low-power mode")
+			level.Error(logger).Log("msg", "Device open failed, device did not return an IDENTIFY DEVICE structure, or device is in a low-power mode", "device", device)
 			result = false
 		}
 		if (b & (1 << 2)) != 0 {
-			level.Warn(logger).Log("msg", "Some SMART or other ATA command to the disk failed, or there was a checksum error in a SMART data structure")
+			level.Warn(logger).Log("msg", "Some SMART or other ATA command to the disk failed, or there was a checksum error in a SMART data structure", "device", device)
 		}
 		if (b & (1 << 3)) != 0 {
-			level.Warn(logger).Log("msg", "SMART status check returned 'DISK FAILING'.")
+			level.Warn(logger).Log("msg", "SMART status check returned 'DISK FAILING'", "device", device)
 		}
 		if (b & (1 << 4)) != 0 {
-			level.Warn(logger).Log("msg", "We found prefail Attributes <= threshold.")
+			level.Warn(logger).Log("msg", "We found prefail Attributes <= threshold", "device", device)
 		}
 		if (b & (1 << 5)) != 0 {
-			level.Warn(logger).Log("msg", "SMART status check returned 'DISK OK' but we found that some (usage or prefail) Attributes have been <= threshold at some time in the past.")
+			level.Warn(logger).Log("msg", "SMART status check returned 'DISK OK' but we found that some (usage or prefail) Attributes have been <= threshold at some time in the past", "device", device)
 		}
 		if (b & (1 << 6)) != 0 {
-			level.Warn(logger).Log("msg", "The device error log contains records of errors.")
+			level.Warn(logger).Log("msg", "The device error log contains records of errors", "device", device)
 		}
 		if (b & (1 << 7)) != 0 {
-			level.Warn(logger).Log("msg", "The device self-test log contains records of errors. [ATA only] Failed self-tests outdated by a newer successful extended self-test are ignored.")
+			level.Warn(logger).Log("msg", "The device self-test log contains records of errors. [ATA only] Failed self-tests outdated by a newer successful extended self-test are ignored", "device", device)
 		}
 	}
 	return result


### PR DESCRIPTION
Without device name is hard to determine on what exactly device `smartctl_exporter` isn't happy

```python
caller=readjson.go:69 level=warn msg="S.M.A.R.T. output reading" err="exit status 2"
caller=readjson.go:123 level=error msg="Device open failed, device did not return an IDENTIFY DEVICE structure, or device is in a low-power mode"
```

```python
caller=readjson.go:69 level=warn msg="S.M.A.R.T. output reading" err="exit status 2" device=/dev/sda
caller=readjson.go:123 level=error msg="Device open failed, device did not return an IDENTIFY DEVICE structure, or device is in a low-power mode" device=/dev/sda
```