### PR TITLE
Fix metricDeviceCount gauge name

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -48,7 +48,7 @@ var (
 		nil,
 	)
 	metricDeviceCount = prometheus.NewDesc(
-		"smartctl_device_count",
+		"smartctl_devices",
 		"Number of devices configured or dynamically discovered",
 		[]string{},
 		nil,


### PR DESCRIPTION
Prometheus naming conventions reserve `_count` for the counter in histograms. For gauge values the naming convention is to use the plural of the thing being counted.