### PR TITLE
Small fixes & added NVMe total capacity metric

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -69,6 +69,14 @@ var (
 		},
 		nil,
 	)
+	metricDeviceTotalCapacityBytes = prometheus.NewDesc(
+		"smartctl_device_nvme_capacity_bytes",
+		"NVMe device total capacity bytes",
+		[]string{
+			"device",
+		},
+		nil,
+	)
 	metricDeviceBlockSize = prometheus.NewDesc(
 		"smartctl_device_block_size",
 		"Device block size",
@@ -274,9 +282,6 @@ var (
 		"Device SCSI grown defect list counter",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -285,9 +290,6 @@ var (
 		"Read Errors Corrected by ReReads/ReWrites",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -296,9 +298,6 @@ var (
 		"Read Total Uncorrected Errors",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -307,9 +306,6 @@ var (
 		"Write Errors Corrected by ReReads/ReWrites",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)
@@ -318,9 +314,6 @@ var (
 		"Write Total Uncorrected Errors",
 		[]string{
 			"device",
-			"model_family",
-			"model_name",
-			"serial_number",
 		},
 		nil,
 	)


### PR DESCRIPTION
* split block mine to `mineBlockSize()` from `mineCapacity()`
* remove redundant meta labels from SCSI metrics
* added `smartctl_device_nvme_capacity_bytes` metric
* for some devices, such as 2.5" NVMe Intel & Micron the `family` field may be empty

The `.user_capacity` exists only when NVMe have single namespace. Otherwise, for NVMe deivces with multiple namespaces, when device name used witout namespace number (exporter case) `.user_capacity` will be absent

```python
smartctl --info --health --attributes \
--tolerance=verypermissive --nocheck=standby --format=brief --log=error \
/dev/nvme11 --json | jq '.user_capacity'

null

smartctl --info --health --attributes \
--tolerance=verypermissive --nocheck=standby --format=brief --log=error \
/dev/nvme11 --json | jq '.nvme_total_capacity'

3840755982336
```

```python
# HELP smartctl_device_available_spare Normalized percentage (0 to 100%) of the remaining spare capacity available
# HELP smartctl_device_capacity_blocks Device capacity in blocks
# TYPE smartctl_device_capacity_blocks gauge
smartctl_device_capacity_blocks{device="nvme0"} 0
smartctl_device_capacity_blocks{device="nvme1"} 0
smartctl_device_capacity_blocks{device="nvme10"} 0
smartctl_device_capacity_blocks{device="nvme11"} 0
smartctl_device_capacity_blocks{device="nvme2"} 0
smartctl_device_capacity_blocks{device="nvme3"} 0
smartctl_device_capacity_blocks{device="nvme4"} 0
smartctl_device_capacity_blocks{device="nvme5"} 0
smartctl_device_capacity_blocks{device="nvme6"} 0
smartctl_device_capacity_blocks{device="nvme7"} 0
smartctl_device_capacity_blocks{device="nvme8"} 0
smartctl_device_capacity_blocks{device="nvme9"} 0
smartctl_device_capacity_blocks{device="sda"} 9.37703088e+08
smartctl_device_capacity_blocks{device="sdb"} 9.37703088e+08
# HELP smartctl_device_capacity_bytes Device capacity in bytes
# TYPE smartctl_device_capacity_bytes gauge
smartctl_device_capacity_bytes{device="nvme0"} 0
smartctl_device_capacity_bytes{device="nvme1"} 0
smartctl_device_capacity_bytes{device="nvme10"} 0
smartctl_device_capacity_bytes{device="nvme11"} 0
smartctl_device_capacity_bytes{device="nvme2"} 0
smartctl_device_capacity_bytes{device="nvme3"} 0
smartctl_device_capacity_bytes{device="nvme4"} 0
smartctl_device_capacity_bytes{device="nvme5"} 0
smartctl_device_capacity_bytes{device="nvme6"} 0
smartctl_device_capacity_bytes{device="nvme7"} 0
smartctl_device_capacity_bytes{device="nvme8"} 0
smartctl_device_capacity_bytes{device="nvme9"} 0
smartctl_device_capacity_bytes{device="sda"} 4.80103981056e+11
smartctl_device_capacity_bytes{device="sdb"} 4.80103981056e+11
# HELP smartctl_device_total_capacity_bytes NVMe device capacity bytes (only for devices with multiple NVMe namespaces)
# TYPE smartctl_device_total_capacity_bytes gauge
smartctl_device_total_capacity_bytes{device="nvme0"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme1"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme10"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme11"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme2"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme3"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme4"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme5"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme6"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme7"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme8"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="nvme9"} 3.840755982336e+12
smartctl_device_total_capacity_bytes{device="sda"} 0
smartctl_device_total_capacity_bytes{device="sdb"} 0
```