### PR TITLE
Fix #158: collect_fake_json.sh

### DIFF
--- a/collect_fake_json.sh
+++ b/collect_fake_json.sh
@@ -1,6 +1,25 @@
 #! /bin/bash
 
-for device in $(smartctl --scan | awk '{ print $1}')
-do
-  smartctl --json --xall $device | jq > debug/$(basename $device).json
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# The original script used --xall but that doesn't work
+# This matches the command in readSMARTctl()
+smartctl_args="--json --info --health --attributes --tolerance=verypermissive --nocheck=standby --format=brief --log=error"
+
+[[ ! -d "${script_dir}/debug" ]] && mkdir --parents "${script_dir}/debug"
+
+if command -v jq >/dev/null; then
+	devices=$(smartctl --scan --json | jq --raw-output '.devices[].name')
+elif command -v yq >/dev/null; then
+	devices=$(smartctl --scan --json | yq --unwrapScalar '.devices[].name')
+elif command -v awk >/dev/null; then
+	devices=$(smartctl --scan | awk '{ print($1) }')
+else
+	devices=$(smartctl --scan | cut -d ' ' -f 1)
+fi
+
+for device in $devices; do
+	echo "Collecting data for '${device}'"
+	# shellcheck disable=SC2086
+	sudo smartctl $smartctl_args "${device}" > "${script_dir}/debug/$(basename "${device}").json"
 done


### PR DESCRIPTION
This fixes the issues in #158 for `collect_fake_json.sh`.

1. The debug directory is created.
2. The script works from other directories by using absolute paths and quoting them.
3. Use `sudo` to gather the data to prevent permission denied in the JSON.
4. Use `jq` and `yq` as alternatives to `awk` to extract the device names.