### PR TITLE
feat: Better SCSI/SAS support, and removing confused metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -44,6 +44,11 @@ var (
 			"ata_version",
 			"sata_version",
 			"form_factor",
+			// scsi_model_name is mapped into model_name
+			"scsi_vendor",
+			"scsi_product",
+			"scsi_revision",
+			"scsi_version",
 		},
 		nil,
 	)
@@ -293,6 +298,22 @@ var (
 		},
 		nil,
 	)
+	metricReadErrorsCorrectedByEccFast = prometheus.NewDesc(
+		"smartctl_read_errors_corrected_by_eccfast",
+		"Read Errors Corrected by ECC Fast",
+		[]string{
+			"device",
+		},
+		nil,
+	)
+	metricReadErrorsCorrectedByEccDelayed = prometheus.NewDesc(
+		"smartctl_read_errors_corrected_by_eccdelayed",
+		"Read Errors Corrected by ECC Delayed",
+		[]string{
+			"device",
+		},
+		nil,
+	)
 	metricReadTotalUncorrectedErrors = prometheus.NewDesc(
 		"smartctl_read_total_uncorrected_errors",
 		"Read Total Uncorrected Errors",
@@ -304,6 +325,22 @@ var (
 	metricWriteErrorsCorrectedByRereadsRewrites = prometheus.NewDesc(
 		"smartctl_write_errors_corrected_by_rereads_rewrites",
 		"Write Errors Corrected by ReReads/ReWrites",
+		[]string{
+			"device",
+		},
+		nil,
+	)
+	metricWriteErrorsCorrectedByEccFast = prometheus.NewDesc(
+		"smartctl_write_errors_corrected_by_eccfast",
+		"Write Errors Corrected by ECC Fast",
+		[]string{
+			"device",
+		},
+		nil,
+	)
+	metricWriteErrorsCorrectedByEccDelayed = prometheus.NewDesc(
+		"smartctl_write_errors_corrected_by_eccdelayed",
+		"Write Errors Corrected by ECC Delayed",
 		[]string{
 			"device",
 		},


### PR DESCRIPTION
Implement better SCSI/SAS support, including less confused metrics.

The exporter, prior to this PR, exports a value of "0" for some metrics
that were specific to certain types of drives; these metrics will no
longer be exported for types where that metric is not valid. Future work
may include parsing the corresponding metrics for SATA/SAS SSDs.

Metrics no longer exported for the wrong type of drive:
- smartctl_device_nvme_capacity_bytes (NVME-specific)
- smartctl_device_available_spare (NVME-specific, ATA possible)
- smartctl_device_available_spare_threshold (NVME-specific, ATA
  possible)
- smartctl_device_critical_warning (NVME-specific, ATA possible)
- smartctl_device_interface_speed (ATA-specific)
- smartctl_device_media_errors (NVME-specific, ATA possible)
- smartctl_device_num_err_log_entries (NVME-specific, SCSI uses distinct
  metrics, ATA possible)
- smartctl_device_nvme_capacity_bytes (NVME-specific)
- smartctl_device_percentage_used (NVME-specific, ATA possible)

Fix the following metrics that were exported as zero because the
exporter did not know how to read them for SCSI devices:
- smartctl_device_bytes_read
- smartctl_device_bytes_written
- smartctl_device_power_cycle_count

New metrics:
- smartctl_read_errors_corrected_by_eccdelayed
- smartctl_read_errors_corrected_by_eccfast
- smartctl_write_errors_corrected_by_eccdelayed
- smartctl_write_errors_corrected_by_eccfast

Fix labels:
- smartctl_device{model_name} is now populated for SCSI/SAS, based on
  scsi_model_name.

New labels:
- smartctl_device{} gains:
  scsi_product,scsi_revision,scsi_vendor,scsi_version

Signed-off-by: Robin H. Johnson <rjohnson@coreweave.com>
