### PR TITLE
collect-smartctl-json: shell fixes for script

### DIFF
--- a/collect-smartctl-json.sh
+++ b/collect-smartctl-json.sh
@@ -8,7 +8,8 @@ data_dir="${script_dir}/smartctl-data"
 
 # The original script used --xall but that doesn't work
 # This matches the command in readSMARTctl()
-smartctl_args="--json --info --health --attributes --tolerance=verypermissive --nocheck=standby --format=brief --log=error"
+smartctl_args="--json --info --health --attributes --tolerance=verypermissive \
+--nocheck=standby --format=brief --log=error"
 
 # Determine the json query tool to use
 if command -v jq >/dev/null; then
@@ -18,18 +19,19 @@ elif command -v yq >/dev/null; then
 	json_tool="yq"
 	json_args="--unwrapScalar"
 else
-	echo "One of 'yq' or 'jq' is required. Please try again after installing one of them"
+	echo -e "One of 'yq' or 'jq' is required. Please try again after \
+installing one of them"
 	exit 1
 fi
 
-if [[ $UID != 0 ]] && ! command -v sudo >/dev/null; then
+if [[ ! "${UID}" -eq 0 ]] && ! command -v sudo >/dev/null; then
 	# Not root and sudo doesn't exist
 	echo "sudo does not exist. Please run this as root"
 	exit 1
 fi
 
 SUDO="sudo"
-if [[ $UID = 0 ]]; then
+if [[ "${UID}" -eq 0 ]]; then
 	# Don't use sudo if root
 	SUDO=""
 fi
@@ -37,18 +39,25 @@ fi
 [[ ! -d "${data_dir}" ]] && mkdir --parents "${data_dir}"
 
 if [[ $# -ne 0 ]]; then
-	devices="$1"
+	devices="${1}"
 else
-	devices=$(smartctl --scan --json | $json_tool $json_args '.devices[].name')
+	devices="$(smartctl --scan --json | "${json_tool}" "${json_args}" \
+'.devices[].name')"
+  mapfile -t devices <<< "${devices[@]}"
 fi
 
-for device in $devices; do
+for device in "${devices[@]}"
+  do
 	echo -n "Collecting data for '${device}'..."
-	data=$($SUDO smartctl $smartctl_args "${device}")
-	type=$(echo "${data}" | $json_tool $json_args '.device.type')
-	family=$(echo "${data}" | $json_tool $json_args '.model_family' | tr ' ' '_')
-	model=$(echo "${data}" | $json_tool $json_args '.model_name' | tr ' ' '_')
-	device_name=$(basename "${device}")
-	echo -e "\tSaving to ${type}-${family}-${model}-${device_name}.json"
-	echo "${data}" > "${data_dir}/${type}-${family}-${model}-${device_name}.json"
+	# shellcheck disable=SC2086
+	data="$($SUDO smartctl ${smartctl_args} ${device})"
+	type="$(echo "${data}" | "${json_tool}" "${json_args}" '.device.type')"
+	family="$(echo "${data}" | "${json_tool}" "${json_args}" \
+'select(.model_family != null) | .model_family | sub(" |/" ; "_" ; "g")')"
+	model="$(echo "${data}" | "${json_tool}" "${json_args}" \
+'.model_name | sub(" |/" ; "_" ; "g")')"
+	device_name="$(basename "${device}")"
+	echo -e "\tSaving to ${type}-${family:=null}-${model}-${device_name}.json"
+	echo "${data}" > \
+"${data_dir}/${type}-${family:=null}-${model}-${device_name}.json"
 done


### PR DESCRIPTION
Shellcheck script & fix issue for SATA Intel SSD:

```sh
Collecting data for '/dev/sda'...       Saving to sat-Intel_S4510/S4610/S4500/S4600_Series_SSDs-INTEL_SSDSC2KG480G8-sda.json
collect-smartctl-json.sh: line 54: /tmp/smartctl-data/sat-Intel_S4510/S4610/S4500/S4600_Series_SSDs-INTEL_SSDSC2KG480G8-sda.json: No such file or directory
```

->

```
[root@ceph-osd2 tmp]# bash collect-smartctl-json.sh
Collecting data for '/dev/sda'...       Saving to sat-Intel_S4510_S4610_S4500_S4600_Series_SSDs-INTEL_SSDSC2KG480G8-sda.json
Collecting data for '/dev/sdb'...       Saving to sat-Intel_S4510_S4610_S4500_S4600_Series_SSDs-INTEL_SSDSC2KG480G8-sdb.json
Collecting data for '/dev/nvme0'...     Saving to nvme-null-Micron_7400_MTFDKCB3T8TDZ-nvme0.json
Collecting data for '/dev/nvme1'...     Saving to nvme-null-Micron_7400_MTFDKCB3T8TDZ-nvme1.json
Collecting data for '/dev/nvme2'...     Saving to nvme-null-Micron_7400_MTFDKCB3T8TDZ-nvme2.json
Collecting data for '/dev/nvme3'...     Saving to nvme-null-Micron_7400_MTFDKCB3T8TDZ-nvme3.json
Collecting data for '/dev/nvme4'...     Saving to nvme-null-INTEL_SSDPF2KX038TZ-nvme4.json
Collecting data for '/dev/nvme5'...     Saving to nvme-null-INTEL_SSDPF2KX038TZ-nvme5.json
Collecting data for '/dev/nvme6'...     Saving to nvme-null-INTEL_SSDPF2KX038TZ-nvme6.json
Collecting data for '/dev/nvme7'...     Saving to nvme-null-INTEL_SSDPF2KX038TZ-nvme7.json
Collecting data for '/dev/nvme8'...     Saving to nvme-null-INTEL_SSDPF2KX038TZ-nvme8.json
Collecting data for '/dev/nvme9'...     Saving to nvme-null-INTEL_SSDPF2KX038TZ-nvme9.json
Collecting data for '/dev/nvme10'...    Saving to nvme-null-INTEL_SSDPE2KX040T8-nvme10.json
Collecting data for '/dev/nvme11'...    Saving to nvme-null-Micron_7450_MTFDKCC3T8TFR-nvme11.json
```