### PR TITLE
Added determining device type and use it at scrape data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.release
 /.tarballs
 debug/
+.idea/
 
 Manifest
 smartctl_exporter

--- a/readjson.go
+++ b/readjson.go
@@ -64,7 +64,7 @@ func readFakeSMARTctl(logger log.Logger, device Device) gjson.Result {
 // Get json from smartctl and parse it
 func readSMARTctl(logger log.Logger, device Device) (gjson.Result, bool) {
 	start := time.Now()
-	out, err := exec.Command(*smartctlPath, "--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", "--log=error", device.Name, "-d", device.Type).Output()
+	out, err := exec.Command(*smartctlPath, "--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", "--log=error", "--device="+device.Type, device.Name).Output()
 	if err != nil {
 		level.Warn(logger).Log("msg", "S.M.A.R.T. output reading", "err", err, "device", device.Info_Name)
 	}

--- a/smartctl.go
+++ b/smartctl.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/go-kit/log"
@@ -42,6 +43,16 @@ type SMARTctl struct {
 	device SMARTDevice
 }
 
+func extractDiskName(input string) string {
+	re := regexp.MustCompile(`^(?:/dev/\S+/\S+\s\[|/dev/|\[)(?:\s\[|)(?P<disk>[a-z0-9_]+)(?:\].*|)$`)
+	match := re.FindStringSubmatch(input)
+
+	if len(match) > 0 {
+		return match[re.SubexpIndex("disk")]
+	}
+	return ""
+}
+
 // NewSMARTctl is smartctl constructor
 func NewSMARTctl(logger log.Logger, json gjson.Result, ch chan<- prometheus.Metric) SMARTctl {
 	var model_name string
@@ -60,7 +71,7 @@ func NewSMARTctl(logger log.Logger, json gjson.Result, ch chan<- prometheus.Metr
 		json:   json,
 		logger: logger,
 		device: SMARTDevice{
-			device:     strings.TrimPrefix(strings.TrimSpace(json.Get("device.name").String()), "/dev/"),
+			device:     extractDiskName(strings.TrimSpace(json.Get("device.info_name").String())),
 			serial:     strings.TrimSpace(json.Get("serial_number").String()),
 			family:     strings.TrimSpace(GetStringIfExists(json, "model_family", "unknown")),
 			model:      strings.TrimSpace(model_name),

--- a/smartctl.go
+++ b/smartctl.go
@@ -44,11 +44,25 @@ type SMARTctl struct {
 }
 
 func extractDiskName(input string) string {
-	re := regexp.MustCompile(`^(?:/dev/\S+/\S+\s\[|/dev/|\[)(?:\s\[|)(?P<disk>[a-z0-9_]+)(?:\].*|)$`)
+	re := regexp.MustCompile(`^(?:/dev/(?P<bus_name>\S+)/(?P<bus_num>\S+)\s\[|/dev/|\[)(?:\s\[|)(?P<disk>[a-z0-9_]+)(?:\].*|)$`)
 	match := re.FindStringSubmatch(input)
 
 	if len(match) > 0 {
-		return match[re.SubexpIndex("disk")]
+		busNameIndex := re.SubexpIndex("bus_name")
+		busNumIndex := re.SubexpIndex("bus_num")
+		diskIndex := re.SubexpIndex("disk")
+		var name []string
+		if busNameIndex != -1 && match[busNameIndex] != "" {
+			name = append(name, match[busNameIndex])
+		}
+		if busNumIndex != -1 && match[busNumIndex] != "" {
+			name = append(name, match[busNumIndex])
+		}
+		if diskIndex != -1 && match[diskIndex] != "" {
+			name = append(name, match[diskIndex])
+		}
+
+		return strings.Join(name, "_")
 	}
 	return ""
 }


### PR DESCRIPTION
Removed smartctl.device param - smartctl.device-include/smartctl.device-exclude fully covers this Added determining device type and use it at scrape data

Maybe fix issues:
https://github.com/prometheus-community/smartctl_exporter/issues/89
https://github.com/prometheus-community/smartctl_exporter/issues/26
And no need pr
https://github.com/prometheus-community/smartctl_exporter/pull/107