### PR TITLE
Add support for device types and predictable device paths 

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,10 @@ var (
 		"smartctl.device-include",
 		"Regexp of devices to exclude from automatic scanning. (mutually exclusive to device-exclude)",
 	).Default("").String()
+	smartctlDeviceTypes = kingpin.Flag(
+		"smartctl.device-type",
+		"Device type to use during automatic scan. Special by-id value forces predictable device names. (repeatable)",
+	).Strings()
 	smartctlFakeData = kingpin.Flag("smartctl.fake-data",
 		"The device to monitor (repeatable)",
 	).Default("false").Hidden().Bool()

--- a/readjson.go
+++ b/readjson.go
@@ -85,6 +85,9 @@ func readSMARTctlDevices(logger log.Logger) gjson.Result {
 			level.Warn(logger).Log("msg", "S.M.A.R.T. output reading error", "err", err)
 			return gjson.Result{}
 		}
+	} else if err != nil {
+		level.Warn(logger).Log("msg", "S.M.A.R.T. output reading error", "err", err)
+		return gjson.Result{}
 	}
 	return parseJSON(string(out))
 }

--- a/readjson.go
+++ b/readjson.go
@@ -77,7 +77,11 @@ func readSMARTctl(logger log.Logger, device Device) (gjson.Result, bool) {
 
 func readSMARTctlDevices(logger log.Logger) gjson.Result {
 	level.Debug(logger).Log("msg", "Scanning for devices")
-	out, err := exec.Command(*smartctlPath, "--json", "--scan").Output()
+	var scanArgs []string = []string{"--json", "--scan"}
+	for _, d := range *smartctlDeviceTypes {
+		scanArgs = append(scanArgs, "--device", d)
+	}
+	out, err := exec.Command(*smartctlPath, scanArgs...).Output()
 	if exiterr, ok := err.(*exec.ExitError); ok {
 		level.Debug(logger).Log("msg", "Exit Status", "exit_code", exiterr.ExitCode())
 		// The smartctl command returns 2 if devices are sleeping, ignore this error.

--- a/readjson.go
+++ b/readjson.go
@@ -64,21 +64,24 @@ func readFakeSMARTctl(logger log.Logger, device Device) gjson.Result {
 // Get json from smartctl and parse it
 func readSMARTctl(logger log.Logger, device Device) (gjson.Result, bool) {
 	start := time.Now()
-	out, err := exec.Command(*smartctlPath, "--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", "--log=error", "--device="+device.Type, device.Name).Output()
+	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", "--log=error", "--device=" + device.Type, device.Name}
+
+	level.Debug(logger).Log("msg", "Calling smartctl with args", "args", strings.Join(smartctlArgs, " "))
+	out, err := exec.Command(*smartctlPath, smartctlArgs...).Output()
 	if err != nil {
-		level.Warn(logger).Log("msg", "S.M.A.R.T. output reading", "err", err, "device", device.Info_Name)
+		level.Warn(logger).Log("msg", "S.M.A.R.T. output reading", "err", err, "device", device)
 	}
 	json := parseJSON(string(out))
 	rcOk := resultCodeIsOk(logger, device, json.Get("smartctl.exit_status").Int())
 	jsonOk := jsonIsOk(logger, json)
-	level.Debug(logger).Log("msg", "Collected S.M.A.R.T. json data", "device", device.Info_Name, "duration", time.Since(start))
+	level.Debug(logger).Log("msg", "Collected S.M.A.R.T. json data", "device", device, "duration", time.Since(start))
 	return json, rcOk && jsonOk
 }
 
 func readSMARTctlDevices(logger log.Logger) gjson.Result {
 	level.Debug(logger).Log("msg", "Scanning for devices")
 	var scanArgs []string = []string{"--json", "--scan"}
-	for _, d := range *smartctlDeviceTypes {
+	for _, d := range *smartctlScanDeviceTypes {
 		scanArgs = append(scanArgs, "--device", d)
 	}
 	out, err := exec.Command(*smartctlPath, scanArgs...).Output()
@@ -109,7 +112,7 @@ func readData(logger log.Logger, device Device) gjson.Result {
 			jsonCache.Store(device, JSONCache{JSON: json, LastCollect: time.Now()})
 			j, found := jsonCache.Load(device)
 			if !found {
-				level.Warn(logger).Log("msg", "device not found", "device", device.Info_Name)
+				level.Warn(logger).Log("msg", "device not found", "device", device)
 			}
 			return j.(JSONCache).JSON
 		}
@@ -124,30 +127,30 @@ func resultCodeIsOk(logger log.Logger, device Device, SMARTCtlResult int64) bool
 	if SMARTCtlResult > 0 {
 		b := SMARTCtlResult
 		if (b & 1) != 0 {
-			level.Error(logger).Log("msg", "Command line did not parse", "device", device.Info_Name)
+			level.Error(logger).Log("msg", "Command line did not parse", "device", device)
 			result = false
 		}
 		if (b & (1 << 1)) != 0 {
-			level.Error(logger).Log("msg", "Device open failed, device did not return an IDENTIFY DEVICE structure, or device is in a low-power mode", "device", device.Info_Name)
+			level.Error(logger).Log("msg", "Device open failed, device did not return an IDENTIFY DEVICE structure, or device is in a low-power mode", "device", device)
 			result = false
 		}
 		if (b & (1 << 2)) != 0 {
-			level.Warn(logger).Log("msg", "Some SMART or other ATA command to the disk failed, or there was a checksum error in a SMART data structure", "device", device.Info_Name)
+			level.Warn(logger).Log("msg", "Some SMART or other ATA command to the disk failed, or there was a checksum error in a SMART data structure", "device", device)
 		}
 		if (b & (1 << 3)) != 0 {
-			level.Warn(logger).Log("msg", "SMART status check returned 'DISK FAILING'", "device", device.Info_Name)
+			level.Warn(logger).Log("msg", "SMART status check returned 'DISK FAILING'", "device", device)
 		}
 		if (b & (1 << 4)) != 0 {
-			level.Warn(logger).Log("msg", "We found prefail Attributes <= threshold", "device", device.Info_Name)
+			level.Warn(logger).Log("msg", "We found prefail Attributes <= threshold", "device", device)
 		}
 		if (b & (1 << 5)) != 0 {
-			level.Warn(logger).Log("msg", "SMART status check returned 'DISK OK' but we found that some (usage or prefail) Attributes have been <= threshold at some time in the past", "device", device.Info_Name)
+			level.Warn(logger).Log("msg", "SMART status check returned 'DISK OK' but we found that some (usage or prefail) Attributes have been <= threshold at some time in the past", "device", device)
 		}
 		if (b & (1 << 6)) != 0 {
-			level.Warn(logger).Log("msg", "The device error log contains records of errors", "device", device.Info_Name)
+			level.Warn(logger).Log("msg", "The device error log contains records of errors", "device", device)
 		}
 		if (b & (1 << 7)) != 0 {
-			level.Warn(logger).Log("msg", "The device self-test log contains records of errors. [ATA only] Failed self-tests outdated by a newer successful extended self-test are ignored", "device", device.Info_Name)
+			level.Warn(logger).Log("msg", "The device self-test log contains records of errors. [ATA only] Failed self-tests outdated by a newer successful extended self-test are ignored", "device", device)
 		}
 	}
 	return result

--- a/smartctl.go
+++ b/smartctl.go
@@ -43,28 +43,16 @@ type SMARTctl struct {
 	device SMARTDevice
 }
 
-func extractDiskName(input string) string {
-	re := regexp.MustCompile(`^(?:/dev/(?P<bus_name>\S+)/(?P<bus_num>\S+)\s\[|/dev/(?:disk\/by-id\/|disk\/by-path\/|)|\[)(?:\s\[|)(?P<disk>[A-Za-z0-9_\-]+)(?:\].*|)$`)
-	match := re.FindStringSubmatch(input)
+func buildDeviceLabel(inputName string, inputType string) string {
+	// Strip /dev prefix and replace / with _ (/dev/bus/0 becomes bus_0, /dev/disk/by-id/abcd becomes abcd)
+	devReg := regexp.MustCompile(`^/dev/(?:disk/by-id/|disk/by-path/|)`)
+	deviceName := strings.ReplaceAll(devReg.ReplaceAllString(inputName, ""), "/", "_")
 
-	if len(match) > 0 {
-		busNameIndex := re.SubexpIndex("bus_name")
-		busNumIndex := re.SubexpIndex("bus_num")
-		diskIndex := re.SubexpIndex("disk")
-		var name []string
-		if busNameIndex != -1 && match[busNameIndex] != "" {
-			name = append(name, match[busNameIndex])
-		}
-		if busNumIndex != -1 && match[busNumIndex] != "" {
-			name = append(name, match[busNumIndex])
-		}
-		if diskIndex != -1 && match[diskIndex] != "" {
-			name = append(name, match[diskIndex])
-		}
-
-		return strings.Join(name, "_")
+	if strings.Contains(inputType, ",") {
+		return deviceName + "_" + strings.ReplaceAll(inputType, ",", "_")
 	}
-	return ""
+
+	return deviceName
 }
 
 // NewSMARTctl is smartctl constructor
@@ -85,7 +73,7 @@ func NewSMARTctl(logger log.Logger, json gjson.Result, ch chan<- prometheus.Metr
 		json:   json,
 		logger: logger,
 		device: SMARTDevice{
-			device:     extractDiskName(strings.TrimSpace(json.Get("device.info_name").String())),
+			device:     buildDeviceLabel(json.Get("device.name").String(), json.Get("device.type").String()),
 			serial:     strings.TrimSpace(json.Get("serial_number").String()),
 			family:     strings.TrimSpace(GetStringIfExists(json, "model_family", "unknown")),
 			model:      strings.TrimSpace(model_name),

--- a/smartctl.go
+++ b/smartctl.go
@@ -44,7 +44,7 @@ type SMARTctl struct {
 }
 
 func extractDiskName(input string) string {
-	re := regexp.MustCompile(`^(?:/dev/(?P<bus_name>\S+)/(?P<bus_num>\S+)\s\[|/dev/|\[)(?:\s\[|)(?P<disk>[a-z0-9_]+)(?:\].*|)$`)
+	re := regexp.MustCompile(`^(?:/dev/(?P<bus_name>\S+)/(?P<bus_num>\S+)\s\[|/dev/(?:disk\/by-id\/|disk\/by-path\/|)|\[)(?:\s\[|)(?P<disk>[A-Za-z0-9_\-]+)(?:\].*|)$`)
 	match := re.FindStringSubmatch(input)
 
 	if len(match) > 0 {

--- a/smartctl_test.go
+++ b/smartctl_test.go
@@ -1,0 +1,44 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestBuildDeviceLabel(t *testing.T) {
+	tests := []struct {
+		deviceName    string
+		deviceType    string
+		expectedLabel string
+	}{
+		{"/dev/bus/0", "megaraid,1", "bus_0_megaraid_1"},
+		{"/dev/sda", "auto", "sda"},
+		{"/dev/disk/by-id/ata-CT500MX500SSD1_ABCDEFGHIJ", "auto", "ata-CT500MX500SSD1_ABCDEFGHIJ"},
+		// Some cases extracted from smartctl docs. Are these the prettiest?
+		// Probably not. Are they unique enough. Definitely.
+		{"/dev/sg1", "cciss,1", "sg1_cciss_1"},
+		{"/dev/bsg/sssraid0", "sssraid,0,1", "bsg_sssraid0_sssraid_0_1"},
+		{"/dev/cciss/c0d0", "cciss,0", "cciss_c0d0_cciss_0"},
+		{"/dev/sdb", "aacraid,1,0,4", "sdb_aacraid_1_0_4"},
+		{"/dev/twl0", "3ware,1", "twl0_3ware_1"},
+	}
+
+	for _, test := range tests {
+		result := buildDeviceLabel(test.deviceName, test.deviceType)
+		if result != test.expectedLabel {
+			t.Errorf("deviceName=%v deviceType=%v expected=%v result=%v", test.deviceName, test.deviceType, test.expectedLabel, result)
+		}
+	}
+}


### PR DESCRIPTION
This is a couple of tightly related changes:
* Adds a new `--smartctl.scan-device-type` command line option allowing for customization of autodetected device types and enables use of special `by-id` device type that forces use of predictable device paths (`/dev/disk/by-id/...`)
* Reworks `device` label generation - this is now based off `device.name` and `device.type` instead of relying on `device.info_name` - this changes label since #205, but stays compatible with latest stable release, and is probably the best way forward (though I am open for suggestions - I was thinking of adding an extra option to still output device path and type as separate labels)
  * Added some label generation tests as an example.
* Adds an option of specifying device type in `--smartctl.device` call via semicolon separator
  * Example: `--smartctl.device=/dev/bus/0;megaraid,0` will result in: `smartctl -d megaraid,0 /dev/bus/0` and output `device="bus_0_megaraid_0"` metric label)
* Brings back previous autoscan behaviour - specifying `--smartctl.device` will disable autodiscovery.
  * Autodiscovery can still be forcibly reenabled using explicit `--smartctl.scan`, for whatever reason.
* Fixes SATA device discovery broken by aforementioned PR by forcing `auto` type on autodetected `scsi` drives.

Fixes #134, #230, #89, probably #229 too...