### PR TITLE
fix: allow configuring powermode check to work better with SSDs

### DIFF
--- a/readjson.go
+++ b/readjson.go
@@ -63,7 +63,7 @@ func readFakeSMARTctl(logger *slog.Logger, device Device) gjson.Result {
 // Get json from smartctl and parse it
 func readSMARTctl(logger *slog.Logger, device Device) (gjson.Result, bool) {
 	start := time.Now()
-	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", "--log=error", "--device=" + device.Type, device.Name}
+	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=" + *smartctlPowerModeCheck, "--format=brief", "--log=error", "--device=" + device.Type, device.Name}
 
 	logger.Debug("Calling smartctl with args", "args", strings.Join(smartctlArgs, " "))
 	out, err := exec.Command(*smartctlPath, smartctlArgs...).Output()


### PR DESCRIPTION
By setting `--nocheck=never` I can correctly scrape SMART metrics from SSDs that report a `standby` power state:
```shell
# hdparm -C /dev/sda

/dev/sda:
 drive state is:  standby
 ```

fixes #91