### PR TITLE
Improve macOS compatibility

### DIFF
--- a/readjson.go
+++ b/readjson.go
@@ -154,6 +154,12 @@ func jsonIsOk(logger *slog.Logger, json gjson.Result) bool {
 	if messages.Exists() {
 		for _, message := range messages.Array() {
 			if message.Get("severity").String() == "error" {
+				// if the string contains "GetLogPage failed", then ignore it
+				// this is a known issue with Apple internal SSDs
+				if strings.Contains(message.Get("string").String(), "GetLogPage failed") {
+					logger.Warn("Ignoring GetLogPage failed error", "device", json.Get("device.name").String(), "message", message.Get("string").String())
+					continue
+				}
 				logger.Error(message.Get("string").String())
 				return false
 			}

--- a/smartctl.go
+++ b/smartctl.go
@@ -63,7 +63,9 @@ func extractDiskName(input string) string {
 
 		return strings.Join(name, "_")
 	}
-	return ""
+
+	// If the regex doesn't match, return the entire input string
+	return input
 }
 
 // NewSMARTctl is smartctl constructor


### PR DESCRIPTION
Currently, the internal drive in my mac doesn't appear in the metrics because of this error:

```
Read 1 entries from Error Information Log failed: GetLogPage failed: system=0x38, sub=0x0, code=745
```

I'm not sure what this is about, but a google search appears to show this in a lot of macOS smartctl outputs. This PR ignores this error so that the drive metrics can be exported.

Also, device name parsing appears to be broken due to how macOS presents device names to smartctl:

```
> smartctl --json --scan                                                                                                                    4s
{
  "json_format_version": [
    1,
    0
  ],
  "smartctl": {
    "version": [
      7,
      4
    ],
    "pre_release": false,
    "svn_revision": "5530",
    "platform_info": "Darwin 24.1.0 arm64",
    "build_info": "(local build)",
    "argv": [
      "smartctl",
      "--json",
      "--scan"
    ],
    "exit_status": 0
  },
  "devices": [
    {
      "name": "IOService:/AppleARMPE/arm-io@10F00000/AppleH16GFamilyIO/ans@81600000/AppleASCWrapV6/iop-ans-nub/RTBuddy(ANS2)/RTBuddyService/AppleANS3CGv2Controller/NS_01@1",
      "info_name": "IOService:/AppleARMPE/arm-io@10F00000/AppleH16GFamilyIO/ans@81600000/AppleASCWrapV6/iop-ans-nub/RTBuddy(ANS2)/RTBuddyService/AppleANS3CGv2Controller/NS_01@1",
      "type": "nvme",
      "protocol": "NVMe"
    },
    {
      "name": "IOService:/AppleARMPE/arm-io@10F00000/AppleH16GFamilyIO/apciec3@80000000/AppleT8132PCIeC/pcic3-bridge@0/IOPP/pci-bridge@0/IOPP/pci-bridge@1/IOPP/pci144d,a80c@0/IONVMeController/IONVMeBlockStorageDevice@1",
      "info_name": "IOService:/AppleARMPE/arm-io@10F00000/AppleH16GFamilyIO/apciec3@80000000/AppleT8132PCIeC/pcic3-bridge@0/IOPP/pci-bridge@0/IOPP/pci-bridge@1/IOPP/pci144d,a80c@0/IONVMeController/IONVMeBlockStorageDevice@1",
      "type": "nvme",
      "protocol": "NVMe"
    }
  ]
}
```

This PR includes a change to the `extractDiskName` function, such that it returns the entire input string `IOService:/AppleARMPE/arm-io@10F00000/AppleH16GFamilyIO/apciec3@80000000/AppleT8132PCIeC/pcic3-bridge@0/IOPP/pci-bridge@0/IOPP/pci-bridge@1/IOPP/pci144d,a80c@0/IONVMeController/IONVMeBlockStorageDevice@1` as the name instead of an empty string. This resolves the restriction that no two devices can have the same name.