### PR TITLE
Smart status availability

### DIFF
--- a/smartctl.go
+++ b/smartctl.go
@@ -468,12 +468,16 @@ func (smart *SMARTctl) mineSCSIBytesWritten() {
 }
 
 func (smart *SMARTctl) mineSmartStatus() {
-	smart.ch <- prometheus.MustNewConstMetric(
-		metricDeviceSmartStatus,
-		prometheus.GaugeValue,
-		smart.json.Get("smart_status.passed").Float(),
-		smart.device.device,
-	)
+	passed_raw := smart.json.Get("smart_status.passed")
+
+	if passed_raw.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricDeviceSmartStatus,
+			prometheus.GaugeValue,
+			passed_raw.Float(),
+			smart.device.device,
+		)
+	}
 }
 
 func (smart *SMARTctl) mineDeviceStatistics() {

--- a/smartctl.go
+++ b/smartctl.go
@@ -468,12 +468,12 @@ func (smart *SMARTctl) mineSCSIBytesWritten() {
 }
 
 func (smart *SMARTctl) mineSmartStatus() {
-	smartStatus := smart.json.Get("smart_status.passed")
+	smartStatus := smart.json.Get("smart_status")
 	if smartStatus.Exists() {
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricDeviceSmartStatus,
 			prometheus.GaugeValue,
-			smartStatus.Float(),
+			smartStatus.Get("passed").Float(),
 			smart.device.device,
 		)
 	}

--- a/smartctl.go
+++ b/smartctl.go
@@ -468,13 +468,12 @@ func (smart *SMARTctl) mineSCSIBytesWritten() {
 }
 
 func (smart *SMARTctl) mineSmartStatus() {
-	passed_raw := smart.json.Get("smart_status.passed")
-
-	if passed_raw.Exists() {
+	smartStatus := smart.json.Get("smart_status.passed")
+	if smartStatus.Exists() {
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricDeviceSmartStatus,
 			prometheus.GaugeValue,
-			passed_raw.Float(),
+			smartStatus.Float(),
 			smart.device.device,
 		)
 	}


### PR DESCRIPTION
There is no point in exporting `smartctl_device_smart_status` metric for logical devices such as HW Raids if they do not support S.M.A.R.T. We can simply skip the metric if the object `smart_status` is not present.

Closes: #224
Closes: https://github.com/canonical/hardware-observer-operator/issues/357 