### PR TITLE
feat: improve --smartctl.fake-data

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,8 +118,12 @@ var (
 		"Device type to use during automatic scan. Special by-id value forces predictable device names. (repeatable)",
 	).Strings()
 	smartctlFakeData = kingpin.Flag("smartctl.fake-data",
-		"The device to monitor (repeatable)",
+		"Use fake device data for debugging & development",
 	).Default("false").Hidden().Bool()
+	smartctlFakeDataPath = kingpin.Flag(
+		"smartctl.fake-data-path",
+		"Directory to use for fake devices based on smartctl --json output",
+	).Default("debug").Hidden().String()
 )
 
 // scanDevices uses smartctl to gather the list of available devices.

--- a/readjson.go
+++ b/readjson.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -48,9 +49,9 @@ func parseJSON(data string) gjson.Result {
 }
 
 // Reading fake smartctl json
-func readFakeSMARTctl(logger *slog.Logger, device Device) gjson.Result {
+func readFakeSMARTctl(logger *slog.Logger, device Device, fakeDataPath string) gjson.Result {
 	s := strings.Split(device.Name, "/")
-	filename := fmt.Sprintf("debug/%s.json", s[len(s)-1])
+	filename := filepath.Join(fakeDataPath, fmt.Sprintf("%s.json", s[len(s)-1]))
 	logger.Debug("Read fake S.M.A.R.T. data from json", "filename", filename)
 	jsonFile, err := os.ReadFile(filename)
 	if err != nil {
@@ -103,7 +104,7 @@ func readSMARTctlDevices(logger *slog.Logger) gjson.Result {
 // Select json source and parse
 func readData(logger *slog.Logger, device Device) gjson.Result {
 	if *smartctlFakeData {
-		return readFakeSMARTctl(logger, device)
+		return readFakeSMARTctl(logger, device, *smartctlFakeDataPath)
 	}
 
 	cacheValue, cacheOk := jsonCache.Load(device)

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -1,6 +1,6 @@
 This directory contains JSON testing data for parsing validation.
 
-New data can be collected with the `collect_fake_json.sh` script.
+New data can be collected with the `collect-smartctl-json.sh` script.
 
 Sensitive information should been redacted using the `redact_fake_json.py`
 script.
@@ -8,4 +8,4 @@ script.
 TODO: what is a good naming scheme for files in this directory? For first-pass,
 it has been either of `model_name` or `scsi_model_name`, followed by an
 identifier. Why multiple drives of the same model? Testing where one drive has
-fields not present on others, e.g. error counts.
+fields not present on others, e.g. error counts introduced by new firmware versions.


### PR DESCRIPTION
- Add `--smartctl.fake-data-path` to load data from other locations
- Cleanup documentation for fake data

Closes: https://github.com/prometheus-community/smartctl_exporter/issues/245