### PR TITLE
feat: added version collector metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/promslog/flag"
@@ -216,6 +217,7 @@ func main() {
 	}
 
 	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(versioncollector.NewCollector("smartctl_exporter"))
 	reg.MustRegister(
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		collectors.NewGoCollector(),


### PR DESCRIPTION
This PR adds Prometheus build info metric

```
smartctl_exporter_build_info{branch="master",goarch="amd64",goos="linux",goversion="go1.24.0",revision="tarball",tags="unknown",version="0.13.0"} 1
```