### PR TITLE
feat: support for mine NVMe Volatile Memory Backup

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -194,6 +194,14 @@ var (
 		},
 		nil,
 	)
+	metricDeviceVolatileMemoryBackupFailed = prometheus.NewDesc(
+		"smartctl_device_volatile_memory_backup_failed",
+		"Indicates that Volatile Memory Backup (NVMe PLP) is failed",
+		[]string{
+			"device",
+		},
+		nil,
+	)
 	metricDeviceBytesRead = prometheus.NewDesc(
 		"smartctl_device_bytes_read",
 		"",


### PR DESCRIPTION
This PR add's metric, when NVMe PLP is failed (bool). Further use of the drive is unsafe; if the power fails, the data may be lost.

Healthy device
```console
[root@host]# smartctl --json --info --capabilities --health --attributes --tolerance=verypermissive --nocheck=standby --format=brief --log=error --device=nvme /dev/nvme1 | jq .smart_status
{
  "passed": true,
  "nvme": {
    "value": 0
  }
}
```

PLP failed
```console
[root@host]# smartctl --json --info --capabilities --health --attributes --tolerance=verypermissive --nocheck=standby --format=brief --log=error --device=nvme /dev/nvme0 | jq .smart_status
{
  "passed": false,
  "nvme": {
    "value": 16,
    "spare_below_threshold": false,
    "temperature_above_or_below_threshold": false,
    "reliability_degraded": false,
    "media_read_only": false,
    "volatile_memory_backup_failed": true,
    "persistent_memory_region_unreliable": false,
    "other": 0
  }
}
```