### PR TITLE
Enable Docker image for ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64
+DOCKER_ARCHS ?= amd64 arm64
 DOCKER_REPO  ?= prometheuscommunity
 
 include Makefile.common


### PR DESCRIPTION
I did a comparison with postgres_exporter which supports arm64 out of the box - this is the only required change.

Changes previously done in https://github.com/prometheus-community/smartctl_exporter/pull/150 are not required.