### PR TITLE
Gather additional temperature values (add --capabilities smartctl arg)

### DIFF
--- a/readjson.go
+++ b/readjson.go
@@ -64,7 +64,7 @@ func readFakeSMARTctl(logger *slog.Logger, device Device) gjson.Result {
 func readSMARTctl(logger *slog.Logger, device Device, wg *sync.WaitGroup) {
 	defer wg.Done()
 	start := time.Now()
-	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=" + *smartctlPowerModeCheck, "--format=brief", "--log=error", "--device=" + device.Type, device.Name}
+	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--capabilities", "--tolerance=verypermissive", "--nocheck=" + *smartctlPowerModeCheck, "--format=brief", "--log=error", "--device=" + device.Type, device.Name}
 
 	logger.Debug("Calling smartctl with args", "args", strings.Join(smartctlArgs, " "))
 	out, err := exec.Command(*smartctlPath, smartctlArgs...).Output()


### PR DESCRIPTION
Issue:
- https://github.com/prometheus-community/smartctl_exporter/issues/303

Before this patch:

```
# HELP smartctl_device_temperature Device temperature celsius
# TYPE smartctl_device_temperature gauge
smartctl_device_temperature{device="nvme0",temperature_type="current"} 80
```

After this patch:

```
# HELP smartctl_device_temperature Device temperature celsius
# TYPE smartctl_device_temperature gauge
smartctl_device_temperature{device="nvme0",temperature_type="critical_limit_max"} 84
smartctl_device_temperature{device="nvme0",temperature_type="current"} 80
smartctl_device_temperature{device="nvme0",temperature_type="op_limit_max"} 80
```
