### PR TITLE
Fix 298 by reusing the label instead of taking it from the json of sm…

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func (i *SMARTctlManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		json := readData(i.logger, device)
 		if json.Exists() {
 			info.SetJSON(json)
-			smart := NewSMARTctl(i.logger, json, ch)
+			smart := NewSMARTctl(i.logger, json, ch, device)
 			smart.Collect()
 		}
 	}

--- a/smartctl.go
+++ b/smartctl.go
@@ -55,7 +55,7 @@ func buildDeviceLabel(inputName string, inputType string) string {
 }
 
 // NewSMARTctl is smartctl constructor
-func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Metric) SMARTctl {
+func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Metric, device Device) SMARTctl {
 	var model_name string
 	if obj := json.Get("model_name"); obj.Exists() {
 		model_name = obj.String()
@@ -72,7 +72,7 @@ func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Me
 		json:   json,
 		logger: logger,
 		device: SMARTDevice{
-			device:     buildDeviceLabel(json.Get("device.name").String(), json.Get("device.type").String()),
+			device:     device.Label,
 			serial:     strings.TrimSpace(json.Get("serial_number").String()),
 			family:     strings.TrimSpace(GetStringIfExists(json, "model_family", "unknown")),
 			model:      strings.TrimSpace(model_name),


### PR DESCRIPTION
This pull request addresses the issue described in [#298](https://github.com/prometheus-community/smartctl_exporter/issues/298), where using multiple devices specified like:

```
smartctl_exporter --smartctl.device="/dev/sda;cciss,0" --smartctl.device="/dev/sda;cciss,1"
```
results in the following error on the metrics endpoint:

`was collected before with the same name and label values`

In [#274](https://github.com/prometheus-community/smartctl_exporter/pull/274), an solution has been implemented adressing this issue. This PR provides an alternative fix by reusing the device labels already created in main.go, instead of reconstructing the label from the smartctl JSON response. Rebuilding the label from the JSON leads to duplicate or incorrect label values.

For the example above, main.go produces the following correct and unique device labels:
```
sda_cciss_0
sda_cciss_1
```
However, in smartctl.go, both devices receive the same label (sda) because the smartctl JSON response contains only:
```

 "device": {
    "name": "/dev/sda",
    "info_name": "/dev/sda [cciss_disk_00] [SCSI]",
    "type": "cciss",
    "protocol": "SCSI"
  },
```
This mismatch results in non-unique labels and ultimately in metric collisions.
By reusing the pre-computed labels from main.go, the collision ist avoided. 