### PR TITLE
Explicitly define the list of possible Desc for the prom client

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,44 @@ type SMARTctlManagerCollector struct {
 
 // Describe sends the super-set of all possible descriptors of metrics
 func (i *SMARTctlManagerCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(i, ch)
+	ch <- metricSmartctlVersion
+	ch <- metricDeviceModel
+	ch <- metricDeviceCount
+	ch <- metricDeviceCapacityBlocks
+	ch <- metricDeviceCapacityBytes
+	ch <- metricDeviceTotalCapacityBytes
+	ch <- metricDeviceBlockSize
+	ch <- metricDeviceInterfaceSpeed
+	ch <- metricDeviceAttribute
+	ch <- metricDevicePowerOnSeconds
+	ch <- metricDeviceRotationRate
+	ch <- metricDeviceTemperature
+	ch <- metricDevicePowerCycleCount
+	ch <- metricDevicePercentageUsed
+	ch <- metricDeviceAvailableSpare
+	ch <- metricDeviceAvailableSpareThreshold
+	ch <- metricDeviceCriticalWarning
+	ch <- metricDeviceMediaErrors
+	ch <- metricDeviceNumErrLogEntries
+	ch <- metricDeviceBytesRead
+	ch <- metricDeviceBytesWritten
+	ch <- metricDeviceSmartStatus
+	ch <- metricDeviceExitStatus
+	ch <- metricDeviceState
+	ch <- metricDeviceStatistics
+	ch <- metricDeviceErrorLogCount
+	ch <- metricDeviceSelfTestLogCount
+	ch <- metricDeviceSelfTestLogErrorCount
+	ch <- metricDeviceERCSeconds
+	ch <- metricSCSIGrownDefectList
+	ch <- metricReadErrorsCorrectedByRereadsRewrites
+	ch <- metricReadErrorsCorrectedByEccFast
+	ch <- metricReadErrorsCorrectedByEccDelayed
+	ch <- metricReadTotalUncorrectedErrors
+	ch <- metricWriteErrorsCorrectedByRereadsRewrites
+	ch <- metricWriteErrorsCorrectedByEccFast
+	ch <- metricWriteErrorsCorrectedByEccDelayed
+	ch <- metricWriteTotalUncorrectedErrors
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.


### PR DESCRIPTION
This PR fixes an issue where the `/metrics` endpoint returns a 500 caused by the error `collected metric XXX with unregistered descriptor Desc`

The error comes from the fact that this service is using the prometheus Go client in a wrong way to initialize the `Desc` that the service will expose. The possible `Desc` values are currently initialized in the prometheus library by calling `prometheus.DescribeByCollect` [here](https://github.com/prometheus-community/smartctl_exporter/blob/d0e5f6af72851f5b3b862d241642192265824157/main.go#L60) as part of the initialization of the service, and it works by collecting all the metrics once to get all the possible `Desc` values. The service here will only collect the metrics for the disks it managed to get stats for ([here](https://github.com/prometheus-community/smartctl_exporter/blob/d0e5f6af72851f5b3b862d241642192265824157/main.go#L69-L74))

This is a problem in various scenario, for example
- all disks are idle: no metrics are collected, so no `Desc` are initialized at all
- disks are running and are in good condition: when a disk goes bad and error metrics start getting reported, these won't have been initialized previously

When looking at the `prometheus.DescribeByCollect` implementation and documentation [here](https://github.com/prometheus/client_golang/blob/fb0838f53562be13697118c31d95d8cb9dc8c470/prometheus/collector.go#L65-L96), it's clear that this method should not be used by this service because of the use-case described in this issue.

Fixes #326