### PR TITLE
Megaraid support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.15.0-megaraid / 2026-03-19
+### Forked from https://github.com/prometheus-community/smart_exporter commit d0e5f6af72851f5b3b862d241642192265824157
+* [ENHANCEMENT] Added support for MegaRAID devices.
+* [ENHANCEMENT] Added hostname and serial number to all metric labels.
+* [ENHANCEMENT] Dockerfile now builds the go binary instead of relying on pre-built binaries.
+* [BUGFIX] Fixed `collect-smartctl-json.sh` script to support MegaRAID devices.
+* [ENHANCEMENT] Added megaraid devices to `testdata` for future reference.
+
 ## 0.14.0 / 2025-04-22
 
 * [BUGFIX] `smart_status` exported if object is present #260

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# Modified 2026-03-19: Changed to multi-stage build for self-contained container builds
+# Changes:
+#   - Added Go build stage to compile binary within Docker (no pre-built artifacts needed)
+#   - Optimized layer caching by copying go.mod/go.sum before source code
+
 # Build stage
 FROM docker.io/golang:1.26-alpine3.23 AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,34 @@
-ARG ARCH="amd64"
-ARG OS="linux"
+# Build stage
+FROM docker.io/golang:1.26-alpine3.23 AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the binary
+# CGO_ENABLED=0 for static binary, -ldflags for smaller binary
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-w -s" -o smartctl_exporter .
+
+# Runtime stage
 FROM alpine:3
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+LABEL ARCH="amd64"
+LABEL OS="linux"
+RUN apk add --no-cache smartmontools
 
-RUN apk add smartmontools
-
-ARG ARCH="amd64"
-ARG OS="linux"
-COPY .build/${OS}-${ARCH}/smartctl_exporter /bin/smartctl_exporter
+COPY --from=builder /build/smartctl_exporter /bin/smartctl_exporter
 
 EXPOSE      9633
 USER        nobody

--- a/Makefile.common
+++ b/Makefile.common
@@ -220,7 +220,7 @@ common-docker-repo-name:
 .PHONY: common-docker $(BUILD_DOCKER_ARCHS)
 common-docker: $(BUILD_DOCKER_ARCHS)
 $(BUILD_DOCKER_ARCHS): common-docker-%:
-	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)" \
+	docker build --no-cache -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)" \
 		-f $(DOCKERFILE_PATH) \
 		--build-arg ARCH="$*" \
 		--build-arg OS="linux" \

--- a/collect-smartctl-json.sh
+++ b/collect-smartctl-json.sh
@@ -11,8 +11,9 @@ data_dir="${script_dir}/smartctl-data"
 smartctl_args="--json --info --health --attributes --tolerance=verypermissive \
 --nocheck=standby --format=brief --log=error"
 
-# Ignore this devices
-smartctl_ignore_dev_regex="^(/dev/bus)"
+# Ignore these devices (empty by default to include all devices including /dev/bus for RAID controllers)
+# Example: smartctl_ignore_dev_regex="^(/dev/sg)"
+smartctl_ignore_dev_regex=""
 
 # Determine the json query tool to use
 if command -v jq >/dev/null; then
@@ -43,26 +44,46 @@ fi
 
 if [[ $# -ne 0 ]]; then
 	devices="${1}"
+	mapfile -t devices <<< "${devices[@]}"
 else
-	devices="$(smartctl --scan --json | "${json_tool}" "${json_args}" \
-".devices[].name | select(test(\"${smartctl_ignore_dev_regex}\") | not)")"
-  mapfile -t devices <<< "${devices[@]}"
+	# Get both device name and type from smartctl scan
+	scan_output="$(smartctl --scan --json)"
+	devices=()
+	while IFS= read -r device_json; do
+		dev_name=$(echo "${device_json}" | "${json_tool}" "${json_args}" '.name')
+		dev_type=$(echo "${device_json}" | "${json_tool}" "${json_args}" '.type')
+		dev_label="${dev_name}"
+		# Filter out ignored devices
+		if [[ -n "${smartctl_ignore_dev_regex}" ]] && [[ "${dev_label}" =~ ${smartctl_ignore_dev_regex} ]]; then
+			continue
+		fi
+		devices+=("${dev_name};${dev_type}")
+	done < <(echo "${scan_output}" | "${json_tool}" "${json_args}" -c '.devices[]')
 fi
 
-for device in "${devices[@]}"
+for device_spec in "${devices[@]}"
   do
-	echo -n "Collecting data for '${device}'..."
+	# Split device spec into name and type (format: /dev/sdX;type or just /dev/sdX)
+	IFS=';' read -r device device_type <<< "${device_spec}"
+	[[ -z "${device_type}" ]] && device_type="auto"
+
+	echo -n "Collecting data for '${device}' with type '${device_type}'..."
 	# shellcheck disable=SC2086
-	data="$($SUDO smartctl ${smartctl_args} ${device})"
+	data="$($SUDO smartctl ${smartctl_args} --device=${device_type} ${device})"
 	# Accommodate a smartmontools pre-7.3 bug
 	data=${data#"  Pending defect count:"}
 	type="$(echo "${data}" | "${json_tool}" "${json_args}" '.device.type')"
 	family="$(echo "${data}" | "${json_tool}" "${json_args}" \
 'select(.model_family != null) | .model_family | sub(" |/" ; "_" ; "g")
  | sub("\"|\\(|\\)" ; "" ; "g")')"
+	# SCSI devices use scsi_model_name instead of model_name
 	model="$(echo "${data}" | "${json_tool}" "${json_args}" \
-'.model_name | sub(" |/" ; "_" ; "g") | sub("\"|\\(|\\)" ; "" ; "g")')"
+'(.model_name // .scsi_model_name // "unknown") | sub(" |/" ; "_" ; "g") | sub("\"|\\(|\\)" ; "" ; "g")')"
 	device_name="$(basename "${device}")"
+	# For megaraid devices, basename returns "0", so use a more descriptive name
+	if [[ "${device_type}" =~ ^(megaraid|sat\+megaraid) ]]; then
+		device_name="${device_name}_${device_type//,/_}"
+	fi
 	echo -e "\tSaving to ${type}-${family:=null}-${model}-${device_name}.json"
 	echo "${data}" > \
 "${data_dir}/${type}-${family:=null}-${model}-${device_name}.json"

--- a/collect-smartctl-json.sh
+++ b/collect-smartctl-json.sh
@@ -1,4 +1,10 @@
 #! /bin/bash
+#
+# Modified 2026-03-19: Added MegaRAID RAID controller support
+# Changes:
+#   - Removed /dev/bus device filtering to allow RAID controller devices
+#   - Added device type extraction from smartctl scan to pass correct -d flag
+#   - Added support for scsi_model_name in addition to model_name for SCSI devices
 
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modified 2026-03-19: Added MegaRAID RAID controller support
+// Changes:
+//   - Fixed scanDevices to preserve megaraid device types instead of converting to 'auto'
+//   - Added protocol check to only convert pure SCSI devices, not RAID controller types
 
 package main
 

--- a/main.go
+++ b/main.go
@@ -138,9 +138,13 @@ func scanDevices(logger *slog.Logger) []Device {
 	for _, d := range scanDevices {
 		deviceName := d.Get("name").String()
 		deviceType := d.Get("type").String()
+		deviceProtocol := d.Get("protocol").String()
 
-		// SATA devices are reported as SCSI during scan - fallback to auto scraping
-		if deviceType == "scsi" {
+		// SATA devices behind controllers are reported with protocol=ATA but type=sat+megaraid,N
+		// Pure SCSI devices have both type=scsi and protocol=SCSI
+		// We should not convert megaraid or other controller types to auto
+		// For regular scsi devices, use auto to let smartctl detect if they're actually SATA
+		if deviceType == "scsi" && deviceProtocol == "SCSI" {
 			deviceType = "auto"
 		}
 

--- a/metrics.go
+++ b/metrics.go
@@ -11,6 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modified 2026-03-19: Added serial_number and node_hostname labels to all metrics
+// Changes:
+//   - Added serial_number label to all metric definitions for device tracking
+//   - Added node_hostname label (populated from NODE_HOSTNAME env var) for Kubernetes node identification
+
 package main
 
 import (
@@ -63,6 +68,8 @@ var (
 		"Device capacity in blocks",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -71,6 +78,8 @@ var (
 		"Device capacity in bytes",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -79,6 +88,8 @@ var (
 		"NVMe device total capacity bytes",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -87,6 +98,8 @@ var (
 		"Device block size",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"blocks_type",
 		},
 		nil,
@@ -96,6 +109,8 @@ var (
 		"Device interface speed, bits per second",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"speed_type",
 		},
 		nil,
@@ -105,6 +120,8 @@ var (
 		"Device attributes",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"attribute_name",
 			"attribute_flags_short",
 			"attribute_flags_long",
@@ -118,6 +135,8 @@ var (
 		"Device power on seconds",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -126,6 +145,8 @@ var (
 		"Device rotation rate",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -134,6 +155,8 @@ var (
 		"Device temperature celsius",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"temperature_type",
 		},
 		nil,
@@ -143,6 +166,8 @@ var (
 		"Device power cycle count",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -151,6 +176,8 @@ var (
 		"Device write percentage used",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -159,6 +186,8 @@ var (
 		"Normalized percentage (0 to 100%) of the remaining spare capacity available",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -167,6 +196,8 @@ var (
 		"When the Available Spare falls below the threshold indicated in this field, an asynchronous event completion may occur. The value is indicated as a normalized percentage (0 to 100%)",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -175,6 +206,8 @@ var (
 		"This field indicates critical warnings for the state of the controller",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -183,6 +216,8 @@ var (
 		"Contains the number of occurrences where the controller detected an unrecovered data integrity error. Errors such as uncorrectable ECC, CRC checksum failure, or LBA tag mismatch are included in this field",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -191,6 +226,8 @@ var (
 		"Contains the number of Error Information log entries over the life of the controller",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -199,6 +236,8 @@ var (
 		"",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -207,6 +246,8 @@ var (
 		"",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -215,6 +256,8 @@ var (
 		"General smart status",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -223,6 +266,8 @@ var (
 		"Exit status of smartctl on device",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -231,6 +276,8 @@ var (
 		"Device state (0=active, 1=standby, 2=sleep, 3=dst, 4=offline, 5=sct)",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -239,6 +286,8 @@ var (
 		"Device statistics",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"statistic_table",
 			"statistic_name",
 			"statistic_flags_short",
@@ -251,6 +300,8 @@ var (
 		"Device SMART error log count",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"error_log_type",
 		},
 		nil,
@@ -260,6 +311,8 @@ var (
 		"Device SMART self test log count",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"self_test_log_type",
 		},
 		nil,
@@ -269,6 +322,8 @@ var (
 		"Device SMART self test log error count",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"self_test_log_type",
 		},
 		nil,
@@ -278,6 +333,8 @@ var (
 		"Device SMART Error Recovery Control Seconds",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 			"op_type",
 		},
 		nil,
@@ -287,6 +344,8 @@ var (
 		"Device SCSI grown defect list counter",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -295,6 +354,8 @@ var (
 		"Read Errors Corrected by ReReads/ReWrites",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -303,6 +364,8 @@ var (
 		"Read Errors Corrected by ECC Fast",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -311,6 +374,8 @@ var (
 		"Read Errors Corrected by ECC Delayed",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -319,6 +384,8 @@ var (
 		"Read Total Uncorrected Errors",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -327,6 +394,8 @@ var (
 		"Write Errors Corrected by ReReads/ReWrites",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -335,6 +404,8 @@ var (
 		"Write Errors Corrected by ECC Fast",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -343,6 +414,8 @@ var (
 		"Write Errors Corrected by ECC Delayed",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)
@@ -351,6 +424,8 @@ var (
 		"Write Total Uncorrected Errors",
 		[]string{
 			"device",
+			"serial_number",
+			"node_hostname",
 		},
 		nil,
 	)

--- a/smartctl.go
+++ b/smartctl.go
@@ -102,7 +102,7 @@ func (smart *SMARTctl) Collect() {
 	smart.mineDeviceERC()
 	smart.mineSmartStatus()
 
-	if smart.device.interface_ == "nvme" {
+	if strings.EqualFold(smart.device.protocol, "nvme") {
 		smart.mineNvmePercentageUsed()
 		smart.mineNvmeAvailableSpare()
 		smart.mineNvmeAvailableSpareThreshold()
@@ -113,7 +113,7 @@ func (smart *SMARTctl) Collect() {
 		smart.mineNvmeBytesWritten()
 	}
 	// SCSI, SAS
-	if smart.device.interface_ == "scsi" {
+	if strings.EqualFold(smart.device.protocol, "scsi") {
 		smart.mineSCSIGrownDefectList()
 		smart.mineSCSIErrorCounterLog()
 		smart.mineSCSIBytesRead()

--- a/smartctl.go
+++ b/smartctl.go
@@ -11,16 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Modified 2026-03-19: Added MegaRAID RAID controller support
+// Modified 2026-03-19: Added MegaRAID RAID controller support and metric labels
 // Changes:
 //   - Changed protocol detection to use device.protocol field instead of device.interface_
-//   - This allows SCSI metrics collection for devices behind RAID controllers (e.g., megaraid,N)
+//     This allows SCSI metrics collection for devices behind RAID controllers (e.g., megaraid,N)
+//   - Added serial_number and node_hostname labels to all metrics for device tracking
+//   - node_hostname is populated from NODE_HOSTNAME environment variable (for Kubernetes deployments)
 
 package main
 
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"regexp"
 	"strings"
 
@@ -41,10 +44,17 @@ type SMARTDevice struct {
 
 // SMARTctl object
 type SMARTctl struct {
-	ch     chan<- prometheus.Metric
-	json   gjson.Result
-	logger *slog.Logger
-	device SMARTDevice
+	ch       chan<- prometheus.Metric
+	json     gjson.Result
+	logger   *slog.Logger
+	device   SMARTDevice
+	hostname string
+}
+
+// getNodeHostname returns the node hostname from NODE_HOSTNAME env var, or empty string
+func getNodeHostname() string {
+	// Only use NODE_HOSTNAME if explicitly set (for Kubernetes/containerized environments)
+	return os.Getenv("NODE_HOSTNAME")
 }
 
 func buildDeviceLabel(inputName string, inputType string) string {
@@ -73,9 +83,10 @@ func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Me
 	}
 
 	return SMARTctl{
-		ch:     ch,
-		json:   json,
-		logger: logger,
+		ch:       ch,
+		json:     json,
+		logger:   logger,
+		hostname: getNodeHostname(),
 		device: SMARTDevice{
 			device:     buildDeviceLabel(json.Get("device.name").String(), json.Get("device.type").String()),
 			serial:     strings.TrimSpace(json.Get("serial_number").String()),
@@ -132,6 +143,8 @@ func (smart *SMARTctl) mineExitStatus() {
 		prometheus.GaugeValue,
 		smart.json.Get("smartctl.exit_status").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -168,12 +181,16 @@ func (smart *SMARTctl) mineCapacity() {
 		prometheus.GaugeValue,
 		smart.json.Get("user_capacity.blocks").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 	smart.ch <- prometheus.MustNewConstMetric(
 		metricDeviceCapacityBytes,
 		prometheus.GaugeValue,
 		smart.json.Get("user_capacity.bytes").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 	nvme_total_capacity := smart.json.Get("nvme_total_capacity")
 	if nvme_total_capacity.Exists() {
@@ -182,6 +199,8 @@ func (smart *SMARTctl) mineCapacity() {
 			prometheus.GaugeValue,
 			nvme_total_capacity.Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 	}
 }
@@ -193,6 +212,8 @@ func (smart *SMARTctl) mineBlockSize() {
 			prometheus.GaugeValue,
 			smart.json.Get(fmt.Sprintf("%s_block_size", blockType)).Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 			blockType,
 		)
 	}
@@ -210,6 +231,8 @@ func (smart *SMARTctl) mineInterfaceSpeed() {
 					prometheus.GaugeValue,
 					tSpeed.Get("units_per_second").Float()*tSpeed.Get("bits_per_unit").Float(),
 					smart.device.device,
+					smart.device.serial,
+					smart.hostname,
 					speedType,
 				)
 			}
@@ -241,6 +264,8 @@ func (smart *SMARTctl) mineDeviceAttribute() {
 				prometheus.GaugeValue,
 				attribute.Get(path).Float(),
 				smart.device.device,
+				smart.device.serial,
+				smart.hostname,
 				name,
 				flagsShort,
 				flagsLong,
@@ -260,6 +285,8 @@ func (smart *SMARTctl) minePowerOnSeconds() {
 			prometheus.CounterValue,
 			GetFloatIfExists(pot, "hours", 0)*60*60+GetFloatIfExists(pot, "minutes", 0)*60,
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 	}
 }
@@ -274,6 +301,8 @@ func (smart *SMARTctl) mineRotationRate() {
 			prometheus.GaugeValue,
 			rRate,
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 	}
 }
@@ -288,6 +317,8 @@ func (smart *SMARTctl) mineTemperatures() {
 				prometheus.GaugeValue,
 				value.Float(),
 				smart.device.device,
+				smart.device.serial,
+		smart.hostname,
 				key.String(),
 			)
 			return true
@@ -304,6 +335,8 @@ func (smart *SMARTctl) minePowerCycleCount() {
 			prometheus.CounterValue,
 			powerCycleCount.Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		return
 	}
@@ -316,6 +349,8 @@ func (smart *SMARTctl) minePowerCycleCount() {
 			prometheus.CounterValue,
 			powerCycleCount.Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		return
 	}
@@ -329,6 +364,8 @@ func (smart *SMARTctl) mineDeviceSCTStatus() {
 			prometheus.GaugeValue,
 			status.Get("device_state").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 	}
 }
@@ -339,6 +376,8 @@ func (smart *SMARTctl) mineNvmePercentageUsed() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.percentage_used").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -348,6 +387,8 @@ func (smart *SMARTctl) mineNvmeAvailableSpare() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.available_spare").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -357,6 +398,8 @@ func (smart *SMARTctl) mineNvmeAvailableSpareThreshold() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.available_spare_threshold").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -366,6 +409,8 @@ func (smart *SMARTctl) mineNvmeCriticalWarning() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.critical_warning").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -375,6 +420,8 @@ func (smart *SMARTctl) mineNvmeMediaErrors() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.media_errors").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -384,6 +431,8 @@ func (smart *SMARTctl) mineNvmeNumErrLogEntries() {
 		prometheus.CounterValue,
 		smart.json.Get("nvme_smart_health_information_log.num_err_log_entries").Float(),
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -423,6 +472,8 @@ func (smart *SMARTctl) mineNvmeBytesRead() {
 		// The underlying data_units_written,data_units_read are 128-bit integers
 		data_units_read.Float()*1000.0*512.0,
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -439,6 +490,8 @@ func (smart *SMARTctl) mineNvmeBytesWritten() {
 		// The underlying data_units_written,data_units_read are 128-bit integers
 		data_units_written.Float()*1000.0*512.0,
 		smart.device.device,
+		smart.device.serial,
+		smart.hostname,
 	)
 }
 
@@ -453,6 +506,8 @@ func (smart *SMARTctl) mineSCSIBytesRead() {
 			// that is not the responsibility of the exporter or smartctl
 			SCSIHealth.Get("read.gigabytes_processed").Float()*1e9,
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 	}
 }
@@ -468,6 +523,8 @@ func (smart *SMARTctl) mineSCSIBytesWritten() {
 			// that is not the responsibility of the exporter or smartctl
 			SCSIHealth.Get("write.gigabytes_processed").Float()*1e9,
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 	}
 }
@@ -480,6 +537,8 @@ func (smart *SMARTctl) mineSmartStatus() {
 			prometheus.GaugeValue,
 			smartStatus.Get("passed").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 	}
 }
@@ -498,6 +557,8 @@ func (smart *SMARTctl) mineDeviceStatistics() {
 				prometheus.GaugeValue,
 				statistic.Get("value").Float(),
 				smart.device.device,
+				smart.device.serial,
+		smart.hostname,
 				table,
 				strings.TrimSpace(statistic.Get("name").String()),
 				strings.TrimSpace(statistic.Get("flags.string").String()),
@@ -517,6 +578,8 @@ func (smart *SMARTctl) mineDeviceStatistics() {
 			prometheus.GaugeValue,
 			statistic.Get("value").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 			"SATA PHY Event Counters",
 			strings.TrimSpace(statistic.Get("name").String()),
 			"V---",
@@ -543,6 +606,8 @@ func (smart *SMARTctl) mineDeviceErrorLog() {
 			prometheus.GaugeValue,
 			status.Get("count").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 			logType,
 		)
 	}
@@ -555,6 +620,8 @@ func (smart *SMARTctl) mineDeviceSelfTestLog() {
 			prometheus.GaugeValue,
 			status.Get("count").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 			logType,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
@@ -562,6 +629,8 @@ func (smart *SMARTctl) mineDeviceSelfTestLog() {
 			prometheus.GaugeValue,
 			status.Get("error_count_total").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 			logType,
 		)
 	}
@@ -574,6 +643,8 @@ func (smart *SMARTctl) mineDeviceERC() {
 			prometheus.GaugeValue,
 			status.Get("deciseconds").Float()/10.0,
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 			ercType,
 		)
 	}
@@ -587,6 +658,8 @@ func (smart *SMARTctl) mineSCSIGrownDefectList() {
 			prometheus.GaugeValue,
 			scsi_grown_defect_list.Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 	}
 }
@@ -599,48 +672,64 @@ func (smart *SMARTctl) mineSCSIErrorCounterLog() {
 			prometheus.GaugeValue,
 			SCSIHealth.Get("read.errors_corrected_by_rereads_rewrites").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricReadErrorsCorrectedByEccFast,
 			prometheus.GaugeValue,
 			SCSIHealth.Get("read.errors_corrected_by_eccfast").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricReadErrorsCorrectedByEccDelayed,
 			prometheus.GaugeValue,
 			SCSIHealth.Get("read.errors_corrected_by_eccdelayed").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricReadTotalUncorrectedErrors,
 			prometheus.GaugeValue,
 			SCSIHealth.Get("read.total_uncorrected_errors").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricWriteErrorsCorrectedByRereadsRewrites,
 			prometheus.GaugeValue,
 			SCSIHealth.Get("write.errors_corrected_by_rereads_rewrites").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricWriteErrorsCorrectedByEccFast,
 			prometheus.GaugeValue,
 			SCSIHealth.Get("write.errors_corrected_by_eccfast").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricWriteErrorsCorrectedByEccDelayed,
 			prometheus.GaugeValue,
 			SCSIHealth.Get("write.errors_corrected_by_eccdelayed").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		smart.ch <- prometheus.MustNewConstMetric(
 			metricWriteTotalUncorrectedErrors,
 			prometheus.GaugeValue,
 			SCSIHealth.Get("write.total_uncorrected_errors").Float(),
 			smart.device.device,
+			smart.device.serial,
+			smart.hostname,
 		)
 		// TODO: Should we also export the verify category?
 	}

--- a/smartctl.go
+++ b/smartctl.go
@@ -10,6 +10,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modified 2026-03-19: Added MegaRAID RAID controller support
+// Changes:
+//   - Changed protocol detection to use device.protocol field instead of device.interface_
+//   - This allows SCSI metrics collection for devices behind RAID controllers (e.g., megaraid,N)
 
 package main
 

--- a/testdata/megaraid,0-null-TOSHIBA_AL15SEB24EQY-0_megaraid_0.json
+++ b/testdata/megaraid,0-null-TOSHIBA_AL15SEB24EQY-0_megaraid_0.json
@@ -1,0 +1,125 @@
+{
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_00]",
+		"name": "/dev/bus/0",
+		"protocol": "SCSI",
+		"type": "megaraid,0"
+	},
+	"device_type": {
+		"name": "disk",
+		"scsi_terminology": "Peripheral Device Type [PDT]",
+		"scsi_value": 0
+	},
+	"form_factor": {
+		"name": "2.5 inches",
+		"scsi_value": 3
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"logical_unit_id": "0x1234567890abcdef",
+	"physical_block_size": 4096,
+	"power_on_time": {
+		"hours": 12437,
+		"minutes": 29
+	},
+	"rotation_rate": 10000,
+	"scsi_error_counter_log": {
+		"read": {
+			"correction_algorithm_invocations": 10,
+			"errors_corrected_by_eccdelayed": 4,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 4,
+			"gigabytes_processed": "1521086.436",
+			"total_errors_corrected": 4,
+			"total_uncorrected_errors": 0
+		},
+		"verify": {
+			"correction_algorithm_invocations": 0,
+			"errors_corrected_by_eccdelayed": 0,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 0,
+			"gigabytes_processed": "177655.741",
+			"total_errors_corrected": 0,
+			"total_uncorrected_errors": 0
+		},
+		"write": {
+			"correction_algorithm_invocations": 0,
+			"errors_corrected_by_eccdelayed": 0,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 0,
+			"gigabytes_processed": "56643.667",
+			"total_errors_corrected": 0,
+			"total_uncorrected_errors": 0
+		}
+	},
+	"scsi_grown_defect_list": 0,
+	"scsi_model_name": "TOSHIBA AL15SEB24EQY",
+	"scsi_product": "AL15SEB24EQY",
+	"scsi_protection_interval_bytes_per_lb": 8,
+	"scsi_protection_type": 2,
+	"scsi_revision": "EF06",
+	"scsi_start_stop_cycle_counter": {
+		"accumulated_load_unload_cycles": 23491,
+		"accumulated_start_stop_cycles": 82,
+		"specified_cycle_count_over_device_lifetime": 50000,
+		"specified_load_unload_count_over_device_lifetime": 600000,
+		"week_of_manufacture": "17",
+		"year_of_manufacture": "2024"
+	},
+	"scsi_transport_protocol": {
+		"name": "SAS (SPL-4)",
+		"value": 6
+	},
+	"scsi_vendor": "TOSHIBA",
+	"scsi_version": "SPC-4",
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smart_support": {
+		"available": true,
+		"enabled": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,0",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 0,
+		"platform_info": "REDACTED",
+		"pre_release": false,
+		"svn_revision": "5530",
+		"version": [
+			7,
+			4
+		]
+	},
+	"temperature": {
+		"current": 32,
+		"drive_trip": 65
+	},
+	"temperature_warning": {
+		"enabled": false
+	},
+	"user_capacity": {
+		"blocks": 4688430768,
+		"bytes": 2400476553216
+	}
+}

--- a/testdata/megaraid,1-null-TOSHIBA_MG08SCA16TEY-0.json
+++ b/testdata/megaraid,1-null-TOSHIBA_MG08SCA16TEY-0.json
@@ -1,0 +1,97 @@
+{
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_01]",
+		"name": "/dev/bus/0",
+		"protocol": "SCSI",
+		"type": "megaraid,1"
+	},
+	"device_type": {
+		"name": "disk",
+		"scsi_value": 0
+	},
+	"form_factor": {
+		"name": "3.5 inches",
+		"scsi_value": 2
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "TOSHIBA MG08SCA16TEY",
+	"physical_block_size": 4096,
+	"product": "MG08SCA16TEY",
+	"revision": "EJ08",
+	"rotation_rate": 7200,
+	"scsi_error_counter_log": {
+		"read": {
+			"correction_algorithm_invocations": 376,
+			"errors_corrected_by_eccdelayed": 374,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 374,
+			"gigabytes_processed": "2657380.347",
+			"total_errors_corrected": 374,
+			"total_uncorrected_errors": 0
+		},
+		"verify": {
+			"correction_algorithm_invocations": 160,
+			"errors_corrected_by_eccdelayed": 160,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 160,
+			"gigabytes_processed": "607904.662",
+			"total_errors_corrected": 160,
+			"total_uncorrected_errors": 0
+		},
+		"write": {
+			"correction_algorithm_invocations": 121,
+			"errors_corrected_by_eccdelayed": 59,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 59,
+			"gigabytes_processed": "73889.776",
+			"total_errors_corrected": 59,
+			"total_uncorrected_errors": 0
+		}
+	},
+	"scsi_grown_defect_list": 0,
+	"scsi_version": "SPC-4",
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,1",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 0,
+		"platform_info": "REDACTED",
+		"svn_revision": "5022",
+		"version": [
+			7,
+			1
+		]
+	},
+	"temperature": {
+		"current": 31,
+		"drive_trip": 65
+	},
+	"user_capacity": {
+		"blocks": 31251759104,
+		"bytes": 16000900661248
+	},
+	"vendor": "TOSHIBA"
+}

--- a/testdata/megaraid,2-null-TOSHIBA_AL15SEB24EQY-0_megaraid_2.json
+++ b/testdata/megaraid,2-null-TOSHIBA_AL15SEB24EQY-0_megaraid_2.json
@@ -1,0 +1,125 @@
+{
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_02]",
+		"name": "/dev/bus/0",
+		"protocol": "SCSI",
+		"type": "megaraid,2"
+	},
+	"device_type": {
+		"name": "disk",
+		"scsi_terminology": "Peripheral Device Type [PDT]",
+		"scsi_value": 0
+	},
+	"form_factor": {
+		"name": "2.5 inches",
+		"scsi_value": 3
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"logical_unit_id": "0x1234567890abcdef",
+	"physical_block_size": 4096,
+	"power_on_time": {
+		"hours": 12438,
+		"minutes": 15
+	},
+	"rotation_rate": 10000,
+	"scsi_error_counter_log": {
+		"read": {
+			"correction_algorithm_invocations": 828,
+			"errors_corrected_by_eccdelayed": 483,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 483,
+			"gigabytes_processed": "1524373.897",
+			"total_errors_corrected": 483,
+			"total_uncorrected_errors": 0
+		},
+		"verify": {
+			"correction_algorithm_invocations": 30,
+			"errors_corrected_by_eccdelayed": 30,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 30,
+			"gigabytes_processed": "177654.107",
+			"total_errors_corrected": 30,
+			"total_uncorrected_errors": 0
+		},
+		"write": {
+			"correction_algorithm_invocations": 5,
+			"errors_corrected_by_eccdelayed": 5,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 5,
+			"gigabytes_processed": "56975.734",
+			"total_errors_corrected": 5,
+			"total_uncorrected_errors": 0
+		}
+	},
+	"scsi_grown_defect_list": 0,
+	"scsi_model_name": "TOSHIBA AL15SEB24EQY",
+	"scsi_product": "AL15SEB24EQY",
+	"scsi_protection_interval_bytes_per_lb": 8,
+	"scsi_protection_type": 2,
+	"scsi_revision": "EF06",
+	"scsi_start_stop_cycle_counter": {
+		"accumulated_load_unload_cycles": 23008,
+		"accumulated_start_stop_cycles": 82,
+		"specified_cycle_count_over_device_lifetime": 50000,
+		"specified_load_unload_count_over_device_lifetime": 600000,
+		"week_of_manufacture": "17",
+		"year_of_manufacture": "2024"
+	},
+	"scsi_transport_protocol": {
+		"name": "SAS (SPL-4)",
+		"value": 6
+	},
+	"scsi_vendor": "TOSHIBA",
+	"scsi_version": "SPC-4",
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smart_support": {
+		"available": true,
+		"enabled": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,2",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 0,
+		"platform_info": "REDACTED",
+		"pre_release": false,
+		"svn_revision": "5530",
+		"version": [
+			7,
+			4
+		]
+	},
+	"temperature": {
+		"current": 31,
+		"drive_trip": 65
+	},
+	"temperature_warning": {
+		"enabled": false
+	},
+	"user_capacity": {
+		"blocks": 4688430768,
+		"bytes": 2400476553216
+	}
+}

--- a/testdata/megaraid,2-null-TOSHIBA_MG08SCA16TEY-0.json
+++ b/testdata/megaraid,2-null-TOSHIBA_MG08SCA16TEY-0.json
@@ -1,0 +1,97 @@
+{
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_02]",
+		"name": "/dev/bus/0",
+		"protocol": "SCSI",
+		"type": "megaraid,2"
+	},
+	"device_type": {
+		"name": "disk",
+		"scsi_value": 0
+	},
+	"form_factor": {
+		"name": "3.5 inches",
+		"scsi_value": 2
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "TOSHIBA MG08SCA16TEY",
+	"physical_block_size": 4096,
+	"product": "MG08SCA16TEY",
+	"revision": "EJ08",
+	"rotation_rate": 7200,
+	"scsi_error_counter_log": {
+		"read": {
+			"correction_algorithm_invocations": 40,
+			"errors_corrected_by_eccdelayed": 39,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 39,
+			"gigabytes_processed": "2735324.995",
+			"total_errors_corrected": 39,
+			"total_uncorrected_errors": 0
+		},
+		"verify": {
+			"correction_algorithm_invocations": 10,
+			"errors_corrected_by_eccdelayed": 10,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 10,
+			"gigabytes_processed": "607904.529",
+			"total_errors_corrected": 10,
+			"total_uncorrected_errors": 0
+		},
+		"write": {
+			"correction_algorithm_invocations": 24,
+			"errors_corrected_by_eccdelayed": 12,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 12,
+			"gigabytes_processed": "77987.525",
+			"total_errors_corrected": 12,
+			"total_uncorrected_errors": 0
+		}
+	},
+	"scsi_grown_defect_list": 0,
+	"scsi_version": "SPC-4",
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,2",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 0,
+		"platform_info": "REDACTED",
+		"svn_revision": "5022",
+		"version": [
+			7,
+			1
+		]
+	},
+	"temperature": {
+		"current": 30,
+		"drive_trip": 65
+	},
+	"user_capacity": {
+		"blocks": 31251759104,
+		"bytes": 16000900661248
+	},
+	"vendor": "TOSHIBA"
+}

--- a/testdata/megaraid,3-null-TOSHIBA_MG08SCA16TEY-0.json
+++ b/testdata/megaraid,3-null-TOSHIBA_MG08SCA16TEY-0.json
@@ -1,0 +1,97 @@
+{
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_03]",
+		"name": "/dev/bus/0",
+		"protocol": "SCSI",
+		"type": "megaraid,3"
+	},
+	"device_type": {
+		"name": "disk",
+		"scsi_value": 0
+	},
+	"form_factor": {
+		"name": "3.5 inches",
+		"scsi_value": 2
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "TOSHIBA MG08SCA16TEY",
+	"physical_block_size": 4096,
+	"product": "MG08SCA16TEY",
+	"revision": "EJ08",
+	"rotation_rate": 7200,
+	"scsi_error_counter_log": {
+		"read": {
+			"correction_algorithm_invocations": 14,
+			"errors_corrected_by_eccdelayed": 14,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 14,
+			"gigabytes_processed": "2803566.902",
+			"total_errors_corrected": 14,
+			"total_uncorrected_errors": 0
+		},
+		"verify": {
+			"correction_algorithm_invocations": 2,
+			"errors_corrected_by_eccdelayed": 2,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 2,
+			"gigabytes_processed": "607903.207",
+			"total_errors_corrected": 2,
+			"total_uncorrected_errors": 0
+		},
+		"write": {
+			"correction_algorithm_invocations": 52,
+			"errors_corrected_by_eccdelayed": 23,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 23,
+			"gigabytes_processed": "80355.979",
+			"total_errors_corrected": 23,
+			"total_uncorrected_errors": 0
+		}
+	},
+	"scsi_grown_defect_list": 0,
+	"scsi_version": "SPC-4",
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,3",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 0,
+		"platform_info": "REDACTED",
+		"svn_revision": "5022",
+		"version": [
+			7,
+			1
+		]
+	},
+	"temperature": {
+		"current": 29,
+		"drive_trip": 65
+	},
+	"user_capacity": {
+		"blocks": 31251759104,
+		"bytes": 16000900661248
+	},
+	"vendor": "TOSHIBA"
+}

--- a/testdata/megaraid,4-null-TOSHIBA_MG08SCA16TEY-0.json
+++ b/testdata/megaraid,4-null-TOSHIBA_MG08SCA16TEY-0.json
@@ -1,0 +1,97 @@
+{
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_04]",
+		"name": "/dev/bus/0",
+		"protocol": "SCSI",
+		"type": "megaraid,4"
+	},
+	"device_type": {
+		"name": "disk",
+		"scsi_value": 0
+	},
+	"form_factor": {
+		"name": "3.5 inches",
+		"scsi_value": 2
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "TOSHIBA MG08SCA16TEY",
+	"physical_block_size": 4096,
+	"product": "MG08SCA16TEY",
+	"revision": "EJ08",
+	"rotation_rate": 7200,
+	"scsi_error_counter_log": {
+		"read": {
+			"correction_algorithm_invocations": 25,
+			"errors_corrected_by_eccdelayed": 23,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 23,
+			"gigabytes_processed": "2006527.139",
+			"total_errors_corrected": 23,
+			"total_uncorrected_errors": 0
+		},
+		"verify": {
+			"correction_algorithm_invocations": 0,
+			"errors_corrected_by_eccdelayed": 0,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 0,
+			"gigabytes_processed": "5.074",
+			"total_errors_corrected": 0,
+			"total_uncorrected_errors": 0
+		},
+		"write": {
+			"correction_algorithm_invocations": 0,
+			"errors_corrected_by_eccdelayed": 0,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 0,
+			"gigabytes_processed": "1790.986",
+			"total_errors_corrected": 0,
+			"total_uncorrected_errors": 0
+		}
+	},
+	"scsi_grown_defect_list": 0,
+	"scsi_version": "SPC-4",
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,4",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 0,
+		"platform_info": "REDACTED",
+		"svn_revision": "5022",
+		"version": [
+			7,
+			1
+		]
+	},
+	"temperature": {
+		"current": 29,
+		"drive_trip": 65
+	},
+	"user_capacity": {
+		"blocks": 31251759104,
+		"bytes": 16000900661248
+	},
+	"vendor": "TOSHIBA"
+}

--- a/testdata/megaraid,5-null-TOSHIBA_MG08SCA16TEY-0.json
+++ b/testdata/megaraid,5-null-TOSHIBA_MG08SCA16TEY-0.json
@@ -1,0 +1,97 @@
+{
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_05]",
+		"name": "/dev/bus/0",
+		"protocol": "SCSI",
+		"type": "megaraid,5"
+	},
+	"device_type": {
+		"name": "disk",
+		"scsi_value": 0
+	},
+	"form_factor": {
+		"name": "3.5 inches",
+		"scsi_value": 2
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "TOSHIBA MG08SCA16TEY",
+	"physical_block_size": 4096,
+	"product": "MG08SCA16TEY",
+	"revision": "EJ08",
+	"rotation_rate": 7200,
+	"scsi_error_counter_log": {
+		"read": {
+			"correction_algorithm_invocations": 170,
+			"errors_corrected_by_eccdelayed": 41,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 41,
+			"gigabytes_processed": "2725016.217",
+			"total_errors_corrected": 41,
+			"total_uncorrected_errors": 0
+		},
+		"verify": {
+			"correction_algorithm_invocations": 4,
+			"errors_corrected_by_eccdelayed": 3,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 3,
+			"gigabytes_processed": "607905.686",
+			"total_errors_corrected": 3,
+			"total_uncorrected_errors": 0
+		},
+		"write": {
+			"correction_algorithm_invocations": 35,
+			"errors_corrected_by_eccdelayed": 15,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 15,
+			"gigabytes_processed": "75188.083",
+			"total_errors_corrected": 15,
+			"total_uncorrected_errors": 0
+		}
+	},
+	"scsi_grown_defect_list": 0,
+	"scsi_version": "SPC-4",
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,5",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 0,
+		"platform_info": "REDACTED",
+		"svn_revision": "5022",
+		"version": [
+			7,
+			1
+		]
+	},
+	"temperature": {
+		"current": 32,
+		"drive_trip": 65
+	},
+	"user_capacity": {
+		"blocks": 31251759104,
+		"bytes": 16000900661248
+	},
+	"vendor": "TOSHIBA"
+}

--- a/testdata/megaraid,6-null-TOSHIBA_MG08SCA16TEY-0.json
+++ b/testdata/megaraid,6-null-TOSHIBA_MG08SCA16TEY-0.json
@@ -1,0 +1,97 @@
+{
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_06]",
+		"name": "/dev/bus/0",
+		"protocol": "SCSI",
+		"type": "megaraid,6"
+	},
+	"device_type": {
+		"name": "disk",
+		"scsi_value": 0
+	},
+	"form_factor": {
+		"name": "3.5 inches",
+		"scsi_value": 2
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "TOSHIBA MG08SCA16TEY",
+	"physical_block_size": 4096,
+	"product": "MG08SCA16TEY",
+	"revision": "EJ08",
+	"rotation_rate": 7200,
+	"scsi_error_counter_log": {
+		"read": {
+			"correction_algorithm_invocations": 0,
+			"errors_corrected_by_eccdelayed": 0,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 0,
+			"gigabytes_processed": "1974314.108",
+			"total_errors_corrected": 0,
+			"total_uncorrected_errors": 0
+		},
+		"verify": {
+			"correction_algorithm_invocations": 0,
+			"errors_corrected_by_eccdelayed": 0,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 0,
+			"gigabytes_processed": "5.014",
+			"total_errors_corrected": 0,
+			"total_uncorrected_errors": 0
+		},
+		"write": {
+			"correction_algorithm_invocations": 0,
+			"errors_corrected_by_eccdelayed": 0,
+			"errors_corrected_by_eccfast": 0,
+			"errors_corrected_by_rereads_rewrites": 0,
+			"gigabytes_processed": "1792.004",
+			"total_errors_corrected": 0,
+			"total_uncorrected_errors": 0
+		}
+	},
+	"scsi_grown_defect_list": 0,
+	"scsi_version": "SPC-4",
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,6",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 0,
+		"platform_info": "REDACTED",
+		"svn_revision": "5022",
+		"version": [
+			7,
+			1
+		]
+	},
+	"temperature": {
+		"current": 28,
+		"drive_trip": 65
+	},
+	"user_capacity": {
+		"blocks": 31251759104,
+		"bytes": 16000900661248
+	},
+	"vendor": "TOSHIBA"
+}

--- a/testdata/sat+megaraid,0-null-MZ7KH480HAHQ0D3-0.json
+++ b/testdata/sat+megaraid,0-null-MZ7KH480HAHQ0D3-0.json
@@ -1,0 +1,704 @@
+{
+	"ata_additional_product_id": "DELL(tm)",
+	"ata_smart_attributes": {
+		"revision": 1,
+		"table": [
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": true,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O-RC- ",
+					"updated_online": true,
+					"value": 26
+				},
+				"id": 1,
+				"name": "Raw_Read_Error_Rate",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 200,
+				"when_failed": "",
+				"worst": 200
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 5,
+				"name": "Reallocated_Sector_Ct",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 10,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 9,
+				"name": "Power_On_Hours",
+				"raw": {
+					"string": "34579",
+					"value": 34579
+				},
+				"thresh": 0,
+				"value": 93,
+				"when_failed": "",
+				"worst": 93
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 12,
+				"name": "Power_Cycle_Count",
+				"raw": {
+					"string": "115",
+					"value": 115
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": true,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O-RC- ",
+					"updated_online": true,
+					"value": 26
+				},
+				"id": 13,
+				"name": "Read_Soft_Error_Rate",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 200,
+				"when_failed": "",
+				"worst": 200
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--C- ",
+					"updated_online": true,
+					"value": 19
+				},
+				"id": 177,
+				"name": "Wear_Leveling_Count",
+				"raw": {
+					"string": "322",
+					"value": 322
+				},
+				"thresh": 5,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--C- ",
+					"updated_online": true,
+					"value": 19
+				},
+				"id": 179,
+				"name": "Used_Rsvd_Blk_Cnt_Tot",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 10,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--C- ",
+					"updated_online": true,
+					"value": 18
+				},
+				"id": 180,
+				"name": "Unused_Rsvd_Blk_Cnt_Tot",
+				"raw": {
+					"string": "2125",
+					"value": 2125
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 181,
+				"name": "Program_Fail_Cnt_Total",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 182,
+				"name": "Erase_Fail_Count_Total",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 184,
+				"name": "End-to-End_Error",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 97,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": false,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O---K ",
+					"updated_online": true,
+					"value": 34
+				},
+				"id": 194,
+				"name": "Temperature_Celsius",
+				"raw": {
+					"string": "30",
+					"value": 30
+				},
+				"thresh": 0,
+				"value": 70,
+				"when_failed": "",
+				"worst": 43
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": true,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O-RC- ",
+					"updated_online": true,
+					"value": 26
+				},
+				"id": 195,
+				"name": "Hardware_ECC_Recovered",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "----CK ",
+					"updated_online": false,
+					"value": 48
+				},
+				"id": 198,
+				"name": "Offline_Uncorrectable",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": true,
+					"event_count": true,
+					"performance": true,
+					"prefailure": false,
+					"string": "-OSRCK ",
+					"updated_online": true,
+					"value": 62
+				},
+				"id": 199,
+				"name": "UDMA_CRC_Error_Count",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 201,
+				"name": "Unknown_SSD_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 1,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 202,
+				"name": "Unknown_SSD_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 10,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 233,
+				"name": "Media_Wearout_Indicator",
+				"raw": {
+					"string": "165826013020",
+					"value": 165826013020
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--C- ",
+					"updated_online": true,
+					"value": 18
+				},
+				"id": 235,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "106",
+					"value": 106
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 242,
+				"name": "Total_LBAs_Read",
+				"raw": {
+					"string": "62241226415",
+					"value": 62241226415
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 243,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 244,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": true,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O-RCK ",
+					"updated_online": true,
+					"value": 58
+				},
+				"id": 245,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "99",
+					"value": 99
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 246,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "65535",
+					"value": 65535
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 247,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "65535",
+					"value": 65535
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 248,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "65535",
+					"value": 65535
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 251,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "315221505216",
+					"value": 315221505216
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			}
+		]
+	},
+	"ata_smart_error_log": {
+		"summary": {
+			"count": 0,
+			"revision": 1
+		}
+	},
+	"ata_version": {
+		"major_value": 4092,
+		"minor_value": 94,
+		"string": "ACS-4 T13/BSR INCITS 529 revision 5"
+	},
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_00] [SAT]",
+		"name": "/dev/bus/0",
+		"protocol": "ATA",
+		"type": "sat+megaraid,0"
+	},
+	"firmware_version": "REDACTED",
+	"form_factor": {
+		"ata_value": 3,
+		"name": "2.5 inches"
+	},
+	"in_smartctl_database": false,
+	"interface_speed": {
+		"current": {
+			"bits_per_unit": 100000000,
+			"sata_value": 3,
+			"string": "6.0 Gb/s",
+			"units_per_second": 60
+		},
+		"max": {
+			"bits_per_unit": 100000000,
+			"sata_value": 14,
+			"string": "6.0 Gb/s",
+			"units_per_second": 60
+		}
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "MZ7KH480HAHQ0D3",
+	"physical_block_size": 4096,
+	"power_cycle_count": 115,
+	"power_on_time": {
+		"hours": 34579
+	},
+	"rotation_rate": 0,
+	"sata_version": {
+		"string": "SATA 3.2",
+		"value": 255
+	},
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,0",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 4,
+		"messages": [
+			{
+				"severity": "warning",
+				"string": "Warning: This result is based on an Attribute check."
+			}
+		],
+		"platform_info": "REDACTED",
+		"svn_revision": "5022",
+		"version": [
+			7,
+			1
+		]
+	},
+	"temperature": {
+		"current": 30
+	},
+	"user_capacity": {
+		"blocks": 937703088,
+		"bytes": 480103981056
+	},
+	"wwn": {
+		"id": 1234567890,
+		"naa": 5,
+		"oui": 9528
+	}
+}

--- a/testdata/sat+megaraid,1-null-HFS1T9G3H2X069N-0.json
+++ b/testdata/sat+megaraid,1-null-HFS1T9G3H2X069N-0.json
@@ -1,0 +1,583 @@
+{
+	"ata_additional_product_id": "DELL(tm)",
+	"ata_smart_attributes": {
+		"revision": 0,
+		"table": [
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": true,
+					"event_count": false,
+					"performance": true,
+					"prefailure": false,
+					"string": "-OSR-- ",
+					"updated_online": true,
+					"value": 14
+				},
+				"id": 1,
+				"name": "Raw_Read_Error_Rate",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 6,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 5,
+				"name": "Reallocated_Sector_Ct",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 2,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 9,
+				"name": "Power_On_Hours",
+				"raw": {
+					"string": "12441",
+					"value": 12441
+				},
+				"thresh": 0,
+				"value": 86,
+				"when_failed": "",
+				"worst": 86
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 12,
+				"name": "Power_Cycle_Count",
+				"raw": {
+					"string": "85",
+					"value": 85
+				},
+				"thresh": 20,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": true,
+					"event_count": false,
+					"performance": true,
+					"prefailure": false,
+					"string": "-OSR-K ",
+					"updated_online": true,
+					"value": 46
+				},
+				"id": 13,
+				"name": "Read_Soft_Error_Rate",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 173,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "32",
+					"value": 32
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 175,
+				"name": "Program_Fail_Count_Chip",
+				"raw": {
+					"string": "12",
+					"value": 12
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 179,
+				"name": "Used_Rsvd_Blk_Cnt_Tot",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 2,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "----C- ",
+					"updated_online": false,
+					"value": 16
+				},
+				"id": 180,
+				"name": "Unused_Rsvd_Blk_Cnt_Tot",
+				"raw": {
+					"string": "2921",
+					"value": 2921
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 181,
+				"name": "Program_Fail_Cnt_Total",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 182,
+				"name": "Erase_Fail_Count_Total",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": false,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O---- ",
+					"updated_online": true,
+					"value": 2
+				},
+				"id": 194,
+				"name": "Temperature_Celsius",
+				"raw": {
+					"string": "34 (Min/Max 20/54)",
+					"value": 231929544738
+				},
+				"thresh": 0,
+				"value": 66,
+				"when_failed": "",
+				"worst": 46
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 195,
+				"name": "Hardware_ECC_Recovered",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "----C- ",
+					"updated_online": false,
+					"value": 16
+				},
+				"id": 198,
+				"name": "Offline_Uncorrectable",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": true,
+					"event_count": true,
+					"performance": true,
+					"prefailure": false,
+					"string": "-OSRCK ",
+					"updated_online": true,
+					"value": 62
+				},
+				"id": 199,
+				"name": "UDMA_CRC_Error_Count",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 201,
+				"name": "Unknown_SSD_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 50,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 202,
+				"name": "Unknown_SSD_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 50,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 233,
+				"name": "Media_Wearout_Indicator",
+				"raw": {
+					"string": "23455",
+					"value": 23455
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 235,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "23455",
+					"value": 23455
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 241,
+				"name": "Total_LBAs_Written",
+				"raw": {
+					"string": "24765",
+					"value": 24765
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 245,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "100",
+					"value": 100
+				},
+				"thresh": 1,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			}
+		]
+	},
+	"ata_version": {
+		"major_value": 4092,
+		"minor_value": 0,
+		"string": "ACS-4 (minor revision not indicated)"
+	},
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_01] [SAT]",
+		"name": "/dev/bus/0",
+		"protocol": "ATA",
+		"type": "sat+megaraid,1"
+	},
+	"firmware_version": "REDACTED",
+	"form_factor": {
+		"ata_value": 3,
+		"name": "2.5 inches"
+	},
+	"in_smartctl_database": false,
+	"interface_speed": {
+		"current": {
+			"bits_per_unit": 100000000,
+			"sata_value": 3,
+			"string": "6.0 Gb/s",
+			"units_per_second": 60
+		},
+		"max": {
+			"bits_per_unit": 100000000,
+			"sata_value": 14,
+			"string": "6.0 Gb/s",
+			"units_per_second": 60
+		}
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "HFS1T9G3H2X069N",
+	"physical_block_size": 4096,
+	"power_cycle_count": 85,
+	"power_on_time": {
+		"hours": 12441
+	},
+	"rotation_rate": 0,
+	"sata_version": {
+		"string": "SATA 3.3",
+		"value": 511
+	},
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smart_support": {
+		"available": true,
+		"enabled": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,1",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"drive_database_version": {
+			"string": "7.3/5528"
+		},
+		"exit_status": 4,
+		"messages": [
+			{
+				"severity": "information",
+				"string": "CHECK POWER MODE not implemented, ignoring -n option"
+			},
+			{
+				"severity": "warning",
+				"string": "Warning: This result is based on an Attribute check."
+			}
+		],
+		"platform_info": "REDACTED",
+		"pre_release": false,
+		"svn_revision": "5530",
+		"version": [
+			7,
+			4
+		]
+	},
+	"temperature": {
+		"current": 34
+	},
+	"trim": {
+		"deterministic": true,
+		"supported": true,
+		"zeroed": true
+	},
+	"user_capacity": {
+		"blocks": 3750748848,
+		"bytes": 1920383410176
+	},
+	"wwn": {
+		"id": 1234567890,
+		"naa": 5,
+		"oui": 11330606
+	}
+}

--- a/testdata/sat+megaraid,7-null-MZ7KH480HAHQ0D3-0.json
+++ b/testdata/sat+megaraid,7-null-MZ7KH480HAHQ0D3-0.json
@@ -1,0 +1,704 @@
+{
+	"ata_additional_product_id": "DELL(tm)",
+	"ata_smart_attributes": {
+		"revision": 1,
+		"table": [
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": true,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O-RC- ",
+					"updated_online": true,
+					"value": 26
+				},
+				"id": 1,
+				"name": "Raw_Read_Error_Rate",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 200,
+				"when_failed": "",
+				"worst": 200
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 5,
+				"name": "Reallocated_Sector_Ct",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 10,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 9,
+				"name": "Power_On_Hours",
+				"raw": {
+					"string": "34579",
+					"value": 34579
+				},
+				"thresh": 0,
+				"value": 93,
+				"when_failed": "",
+				"worst": 93
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 12,
+				"name": "Power_Cycle_Count",
+				"raw": {
+					"string": "115",
+					"value": 115
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": true,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O-RC- ",
+					"updated_online": true,
+					"value": 26
+				},
+				"id": 13,
+				"name": "Read_Soft_Error_Rate",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 200,
+				"when_failed": "",
+				"worst": 200
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--C- ",
+					"updated_online": true,
+					"value": 19
+				},
+				"id": 177,
+				"name": "Wear_Leveling_Count",
+				"raw": {
+					"string": "322",
+					"value": 322
+				},
+				"thresh": 5,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--C- ",
+					"updated_online": true,
+					"value": 19
+				},
+				"id": 179,
+				"name": "Used_Rsvd_Blk_Cnt_Tot",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 10,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--C- ",
+					"updated_online": true,
+					"value": 18
+				},
+				"id": 180,
+				"name": "Unused_Rsvd_Blk_Cnt_Tot",
+				"raw": {
+					"string": "2136",
+					"value": 2136
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 181,
+				"name": "Program_Fail_Cnt_Total",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 182,
+				"name": "Erase_Fail_Count_Total",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 184,
+				"name": "End-to-End_Error",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 97,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": false,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O---K ",
+					"updated_online": true,
+					"value": 34
+				},
+				"id": 194,
+				"name": "Temperature_Celsius",
+				"raw": {
+					"string": "30",
+					"value": 30
+				},
+				"thresh": 0,
+				"value": 70,
+				"when_failed": "",
+				"worst": 43
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": true,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O-RC- ",
+					"updated_online": true,
+					"value": 26
+				},
+				"id": 195,
+				"name": "Hardware_ECC_Recovered",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "----CK ",
+					"updated_online": false,
+					"value": 48
+				},
+				"id": 198,
+				"name": "Offline_Uncorrectable",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": true,
+					"event_count": true,
+					"performance": true,
+					"prefailure": false,
+					"string": "-OSRCK ",
+					"updated_online": true,
+					"value": 62
+				},
+				"id": 199,
+				"name": "UDMA_CRC_Error_Count",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 201,
+				"name": "Unknown_SSD_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 1,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": true,
+					"string": "PO--CK ",
+					"updated_online": true,
+					"value": 51
+				},
+				"id": 202,
+				"name": "Unknown_SSD_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 10,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 233,
+				"name": "Media_Wearout_Indicator",
+				"raw": {
+					"string": "165825989468",
+					"value": 165825989468
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": false,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--C- ",
+					"updated_online": true,
+					"value": 18
+				},
+				"id": 235,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "107",
+					"value": 107
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 242,
+				"name": "Total_LBAs_Read",
+				"raw": {
+					"string": "62685391257",
+					"value": 62685391257
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 243,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 244,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "0",
+					"value": 0
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": true,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O-RCK ",
+					"updated_online": true,
+					"value": 58
+				},
+				"id": 245,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "99",
+					"value": 99
+				},
+				"thresh": 0,
+				"value": 99,
+				"when_failed": "",
+				"worst": 99
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 246,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "65535",
+					"value": 65535
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 247,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "65535",
+					"value": 65535
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 248,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "65535",
+					"value": 65535
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			},
+			{
+				"flags": {
+					"auto_keep": true,
+					"error_rate": false,
+					"event_count": true,
+					"performance": false,
+					"prefailure": false,
+					"string": "-O--CK ",
+					"updated_online": true,
+					"value": 50
+				},
+				"id": 251,
+				"name": "Unknown_Attribute",
+				"raw": {
+					"string": "315537860480",
+					"value": 315537860480
+				},
+				"thresh": 0,
+				"value": 100,
+				"when_failed": "",
+				"worst": 100
+			}
+		]
+	},
+	"ata_smart_error_log": {
+		"summary": {
+			"count": 0,
+			"revision": 1
+		}
+	},
+	"ata_version": {
+		"major_value": 4092,
+		"minor_value": 94,
+		"string": "ACS-4 T13/BSR INCITS 529 revision 5"
+	},
+	"device": {
+		"info_name": "/dev/bus/0 [megaraid_disk_07] [SAT]",
+		"name": "/dev/bus/0",
+		"protocol": "ATA",
+		"type": "sat+megaraid,7"
+	},
+	"firmware_version": "REDACTED",
+	"form_factor": {
+		"ata_value": 3,
+		"name": "2.5 inches"
+	},
+	"in_smartctl_database": false,
+	"interface_speed": {
+		"current": {
+			"bits_per_unit": 100000000,
+			"sata_value": 3,
+			"string": "6.0 Gb/s",
+			"units_per_second": 60
+		},
+		"max": {
+			"bits_per_unit": 100000000,
+			"sata_value": 14,
+			"string": "6.0 Gb/s",
+			"units_per_second": 60
+		}
+	},
+	"json_format_version": [
+		1,
+		0
+	],
+	"local_time": {
+		"asctime": "Fri Feb 13 23:31:30 2009 UTC",
+		"time_t": 1234567890
+	},
+	"logical_block_size": 512,
+	"model_name": "MZ7KH480HAHQ0D3",
+	"physical_block_size": 4096,
+	"power_cycle_count": 115,
+	"power_on_time": {
+		"hours": 34579
+	},
+	"rotation_rate": 0,
+	"sata_version": {
+		"string": "SATA 3.2",
+		"value": 255
+	},
+	"serial_number": "REDACTED",
+	"smart_status": {
+		"passed": true
+	},
+	"smartctl": {
+		"argv": [
+			"smartctl",
+			"--json",
+			"--info",
+			"--health",
+			"--attributes",
+			"--tolerance=verypermissive",
+			"--nocheck=standby",
+			"--format=brief",
+			"--log=error",
+			"--device=megaraid,7",
+			"/dev/bus/0"
+		],
+		"build_info": "REDACTED",
+		"exit_status": 4,
+		"messages": [
+			{
+				"severity": "warning",
+				"string": "Warning: This result is based on an Attribute check."
+			}
+		],
+		"platform_info": "REDACTED",
+		"svn_revision": "5022",
+		"version": [
+			7,
+			1
+		]
+	},
+	"temperature": {
+		"current": 30
+	},
+	"user_capacity": {
+		"blocks": 937703088,
+		"bytes": 480103981056
+	},
+	"wwn": {
+		"id": 1234567890,
+		"naa": 5,
+		"oui": 9528
+	}
+}


### PR DESCRIPTION
### Forked from https://github.com/prometheus-community/smart_exporter commit d0e5f6af72851f5b3b862d241642192265824157
* [ENHANCEMENT] Added support for MegaRAID devices.
* [ENHANCEMENT] Added hostname and serial number to all metric labels.
* [ENHANCEMENT] Dockerfile now builds the go binary instead of relying on pre-built binaries.
* [BUGFIX] Fixed `collect-smartctl-json.sh` script to support MegaRAID devices.
* [ENHANCEMENT] Added megaraid devices to `testdata` for future reference.
