### PR TITLE
Handle NVMe devices behind bridges

### DIFF
--- a/smartctl.go
+++ b/smartctl.go
@@ -102,7 +102,7 @@ func (smart *SMARTctl) Collect() {
 	smart.mineDeviceERC()
 	smart.mineSmartStatus()
 
-	if smart.device.interface_ == "nvme" {
+	if smart.device.interface_ == "nvme" || smart.device.protocol == "NVMe" {
 		smart.mineNvmePercentageUsed()
 		smart.mineNvmeAvailableSpare()
 		smart.mineNvmeAvailableSpareThreshold()


### PR DESCRIPTION
NVMe devices behind USB bridges/etc might use a different interface, but still report the protocol as "NVMe". Also collect stats from those.