### PR TITLE
Add Seagate FARM log metrics, vdev-label support, deploy tooling, and Grafana dashboard

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy smartctl_exporter with FARM log support and Grafana dashboard.
+#
+# Usage:
+#   ./deploy.sh <target_host>
+#
+# Examples:
+#   ./deploy.sh 192.168.5.114
+#   ./deploy.sh 192.168.5.114 192.168.5.115 192.168.5.116
+#
+# Environment variables:
+#   SSH_USER       - SSH user (default: root)
+#   GRAFANA_USER   - Grafana admin user (default: admin)
+#   GRAFANA_PASS   - Grafana admin password (default: admin)
+#   GRAFANA_HOST   - Override Grafana host (default: auto-detect from target)
+#
+# Prerequisites:
+#   - SSH root access to target hosts
+#   - Go installed locally for building
+#   - Prometheus with scrape_config_files including /etc/prometheus/scrape_configs/
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SSH_USER="${SSH_USER:-root}"
+GRAFANA_USER="${GRAFANA_USER:-admin}"
+GRAFANA_PASS="${GRAFANA_PASS:-admin}"
+GRAFANA_HOST="${GRAFANA_HOST:-}"
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <target_host> [target_host2] ..."
+    exit 1
+fi
+
+echo "==> Building smartctl_exporter..."
+cd "$SCRIPT_DIR"
+GOOS=linux GOARCH=amd64 go build -o smartctl_exporter .
+
+for TARGET in "$@"; do
+    echo ""
+    echo "========================================"
+    echo "==> Deploying to ${TARGET}"
+    echo "========================================"
+
+    echo "==> Copying binary..."
+    scp smartctl_exporter "${SSH_USER}@${TARGET}:/usr/bin/smartctl_exporter"
+
+    echo "==> Installing systemd service..."
+    scp systemd/smartctl_exporter.service "${SSH_USER}@${TARGET}:/etc/systemd/system/smartctl_exporter.service"
+
+    echo "==> Installing Prometheus scrape config..."
+    ssh "${SSH_USER}@${TARGET}" "mkdir -p /etc/prometheus/scrape_configs"
+    scp smartctl_exporter.yml "${SSH_USER}@${TARGET}:/etc/prometheus/scrape_configs/smartctl_exporter.yml"
+
+    echo "==> Enabling and starting smartctl_exporter..."
+    ssh "${SSH_USER}@${TARGET}" "systemctl daemon-reload && systemctl enable --now smartctl_exporter && systemctl restart smartctl_exporter"
+
+    echo "==> Restarting Prometheus (if installed)..."
+    ssh "${SSH_USER}@${TARGET}" "systemctl restart prometheus 2>/dev/null || true"
+
+    # Check if Grafana is running on this node and import dashboard
+    GRAFANA_TARGET="${GRAFANA_HOST:-$TARGET}"
+    if ssh "${SSH_USER}@${TARGET}" "systemctl is-active grafana-server >/dev/null 2>&1"; then
+        echo "==> Grafana detected on ${TARGET}, importing dashboard..."
+        sleep 5
+        curl -sf -u "${GRAFANA_USER}:${GRAFANA_PASS}" \
+            -X POST -H "Content-Type: application/json" \
+            "http://${GRAFANA_TARGET}:3000/api/dashboards/db" \
+            -d @"${SCRIPT_DIR}/smartctl-farm-dashboard.json" \
+            && echo "    Dashboard imported." \
+            || echo "    WARNING: Dashboard import failed."
+    else
+        echo "==> Grafana not running on ${TARGET}, skipping dashboard import."
+    fi
+
+    echo "==> ${TARGET} done. Exporter at http://${TARGET}:9633/metrics"
+done
+
+echo ""
+echo "==> Deployment complete!"

--- a/deploy.sh
+++ b/deploy.sh
@@ -148,18 +148,50 @@ scrape_configs:
 EOF
 else
     echo "    Using inline prometheus.yml style..."
-    # Remove existing smartctl job block if present, then append new one
-    ssh "${SSH_USER}@${PROM_HOST}" "
-        # Remove old smartctl block (job_name line + following lines until next job or EOF)
-        sed -i '/job_name:.*smartctl/,/^  - job_name\\|^\$/{/^  - job_name.*smartctl/d;/^  - job_name/!d}' /etc/prometheus/prometheus.yml 2>/dev/null || true
-        # Append new smartctl job
-        cat >> /etc/prometheus/prometheus.yml <<INNER
-  - job_name: 'smartctl'
-    scrape_interval: 60s
-    static_configs:
-      - targets: [${TARGETS_INLINE}]
-INNER
-    "
+    # Use Python for YAML-aware insertion: removes any existing smartctl job,
+    # then inserts the new one before the 'alerting:' block (or appends to
+    # scrape_configs if no alerting block exists). This avoids the bug where
+    # blindly appending to EOF places the job inside the alerting block.
+    ssh "${SSH_USER}@${PROM_HOST}" "python3 - /etc/prometheus/prometheus.yml ${TARGETS_INLINE}" <<'PYEOF'
+import sys, re
+
+cfg = sys.argv[1]
+targets = sys.argv[2:]
+
+with open(cfg) as f:
+    content = f.read()
+
+# Remove any existing smartctl job block (idempotent).
+content = re.sub(
+    r"(?m)^  - job_name: ['\"]smartctl['\"].*\n(?:    [^\n]*\n)*",
+    '',
+    content
+)
+
+# Build the new job block.
+target_list = ', '.join(targets)
+job = (
+    "  - job_name: 'smartctl'\n"
+    "    scrape_interval: 60s\n"
+    "    static_configs:\n"
+    f"      - targets: [{target_list}]\n"
+)
+
+# Insert before 'alerting:' if present, otherwise append to end.
+if re.search(r'^alerting:', content, re.MULTILINE):
+    content = re.sub(
+        r'^(alerting:)',
+        lambda m: job + m.group(1),
+        content,
+        count=1,
+        flags=re.MULTILINE
+    )
+else:
+    content = content.rstrip('\n') + '\n' + job
+
+with open(cfg, 'w') as f:
+    f.write(content)
+PYEOF
 fi
 
 echo "==> Restarting Prometheus on ${PROM_HOST}..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,11 +57,21 @@ for TARGET in "$@"; do
     echo "==> Checking smartctl version..."
     ssh "${SSH_USER}@${TARGET}" "smartctl --version | head -1"
 
+    echo "==> Stopping existing service (if running)..."
+    ssh "${SSH_USER}@${TARGET}" "systemctl stop smartctl_exporter 2>/dev/null || true"
+
     echo "==> Copying binary..."
     scp smartctl_exporter "${SSH_USER}@${TARGET}:/usr/bin/smartctl_exporter"
 
     echo "==> Installing systemd service..."
     scp systemd/smartctl_exporter.service "${SSH_USER}@${TARGET}:/etc/systemd/system/smartctl_exporter.service"
+
+    # If smartctl is not at the default path, add --smartctl.path to the service file
+    SMARTCTL_PATH=$(ssh "${SSH_USER}@${TARGET}" "which smartctl 2>/dev/null || echo /usr/sbin/smartctl")
+    if [[ "$SMARTCTL_PATH" != "/usr/sbin/smartctl" ]]; then
+        echo "    smartctl found at ${SMARTCTL_PATH}, updating service file..."
+        ssh "${SSH_USER}@${TARGET}" "sed -i 's|--smartctl.farm-log|--smartctl.farm-log --smartctl.path=${SMARTCTL_PATH}|' /etc/systemd/system/smartctl_exporter.service"
+    fi
 
     echo "==> Enabling and starting smartctl_exporter..."
     ssh "${SSH_USER}@${TARGET}" "systemctl daemon-reload && systemctl enable --now smartctl_exporter && systemctl restart smartctl_exporter"
@@ -71,10 +81,22 @@ for TARGET in "$@"; do
     if ssh "${SSH_USER}@${TARGET}" "systemctl is-active grafana-server >/dev/null 2>&1"; then
         echo "==> Grafana detected on ${TARGET}, importing dashboard..."
         sleep 5
-        curl -sf -u "${GRAFANA_USER}:${GRAFANA_PASS}" \
+        # Import dashboard with instance regex cleared (we use IPs, not localhost)
+        python3 -c "
+import sys, json
+with open('${SCRIPT_DIR}/smartctl-farm-dashboard.json') as f:
+    d = json.load(f)
+for var in d.get('dashboard', d).get('templating', {}).get('list', []):
+    if var.get('name') == 'instance':
+        var['regex'] = ''
+d.setdefault('overwrite', True)
+if 'dashboard' in d:
+    d['dashboard']['id'] = None
+print(json.dumps(d))
+" | curl -sf -u "${GRAFANA_USER}:${GRAFANA_PASS}" \
             -X POST -H "Content-Type: application/json" \
             "http://${GRAFANA_TARGET}:3000/api/dashboards/db" \
-            -d @"${SCRIPT_DIR}/smartctl-farm-dashboard.json" \
+            -d @- \
             && echo "    Dashboard imported." \
             || echo "    WARNING: Dashboard import failed."
     else
@@ -98,20 +120,41 @@ if ! ssh "${SSH_USER}@${PROM_HOST}" "systemctl list-unit-files prometheus.servic
 fi
 
 # Build targets list from all deployed hosts
-TARGETS=""
+TARGETS_YAML=""
+TARGETS_INLINE=""
 for TARGET in "$@"; do
-    if [[ -n "$TARGETS" ]]; then
-        TARGETS="${TARGETS}, "
+    if [[ -n "$TARGETS_INLINE" ]]; then
+        TARGETS_INLINE="${TARGETS_INLINE}, "
     fi
-    TARGETS="${TARGETS}'${TARGET}:9633'"
+    TARGETS_INLINE="${TARGETS_INLINE}'${TARGET}:9633'"
+    TARGETS_YAML="${TARGETS_YAML}
+      - targets: ['${TARGET}:9633']"
 done
 
-ssh "${SSH_USER}@${PROM_HOST}" "mkdir -p /etc/prometheus/scrape_configs && cat > /etc/prometheus/scrape_configs/smartctl_exporter.yml" <<EOF
+# Determine Prometheus config style: scrape_config_files or inline prometheus.yml
+if ssh "${SSH_USER}@${PROM_HOST}" "grep -q 'scrape_config_files' /etc/prometheus/prometheus.yml 2>/dev/null"; then
+    echo "    Using scrape_config_files style..."
+    ssh "${SSH_USER}@${PROM_HOST}" "mkdir -p /etc/prometheus/scrape_configs && cat > /etc/prometheus/scrape_configs/smartctl_exporter.yml" <<EOF
 scrape_configs:
   - job_name: 'smartctl'
     static_configs:
-      - targets: [${TARGETS}]
+      - targets: [${TARGETS_INLINE}]
 EOF
+else
+    echo "    Using inline prometheus.yml style..."
+    # Remove existing smartctl job block if present, then append new one
+    ssh "${SSH_USER}@${PROM_HOST}" "
+        # Remove old smartctl block (job_name line + following lines until next job or EOF)
+        sed -i '/job_name:.*smartctl/,/^  - job_name\\|^\$/{/^  - job_name.*smartctl/d;/^  - job_name/!d}' /etc/prometheus/prometheus.yml 2>/dev/null || true
+        # Append new smartctl job
+        cat >> /etc/prometheus/prometheus.yml <<INNER
+  - job_name: 'smartctl'
+    scrape_interval: 60s
+    static_configs:
+      - targets: [${TARGETS_INLINE}]
+INNER
+    "
+fi
 
 echo "==> Restarting Prometheus on ${PROM_HOST}..."
 ssh "${SSH_USER}@${PROM_HOST}" "systemctl restart prometheus 2>/dev/null || true"

--- a/deploy.sh
+++ b/deploy.sh
@@ -73,6 +73,12 @@ for TARGET in "$@"; do
         ssh "${SSH_USER}@${TARGET}" "sed -i 's|--smartctl.farm-log|--smartctl.farm-log --smartctl.path=${SMARTCTL_PATH}|' /etc/systemd/system/smartctl_exporter.service"
     fi
 
+    # Check if the target has ID_VDEV udev data (ZFS vdev labels / enclosure slots)
+    if ssh "${SSH_USER}@${TARGET}" "udevadm info --export --query=property /dev/\$(lsblk -dn -o NAME | head -1) 2>/dev/null | grep -q ID_VDEV"; then
+        echo "    ID_VDEV detected, ensuring --smartctl.vdev-label is set..."
+        ssh "${SSH_USER}@${TARGET}" "grep -q 'vdev-label' /etc/systemd/system/smartctl_exporter.service || sed -i 's|--smartctl.farm-log|--smartctl.farm-log --smartctl.vdev-label|' /etc/systemd/system/smartctl_exporter.service"
+    fi
+
     echo "==> Enabling and starting smartctl_exporter..."
     ssh "${SSH_USER}@${TARGET}" "systemctl daemon-reload && systemctl enable --now smartctl_exporter && systemctl restart smartctl_exporter"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,9 +41,9 @@ if [[ $# -eq 0 ]]; then
     exit 1
 fi
 
-echo "==> Building smartctl_exporter..."
+echo "==> Building smartctl_exporter (static)..."
 cd "$SCRIPT_DIR"
-GOOS=linux GOARCH=amd64 go build -o smartctl_exporter .
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o smartctl_exporter .
 
 for TARGET in "$@"; do
     echo ""

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,17 +4,23 @@ set -euo pipefail
 # Deploy smartctl_exporter with FARM log support and Grafana dashboard.
 #
 # Usage:
-#   ./deploy.sh <target_host>
+#   ./deploy.sh <target_host> [target_host2] ...
 #
 # Examples:
 #   ./deploy.sh 192.168.5.114
 #   ./deploy.sh 192.168.5.114 192.168.5.115 192.168.5.116
 #
 # Environment variables:
-#   SSH_USER       - SSH user (default: root)
-#   GRAFANA_USER   - Grafana admin user (default: admin)
-#   GRAFANA_PASS   - Grafana admin password (default: admin)
-#   GRAFANA_HOST   - Override Grafana host (default: auto-detect from target)
+#   SSH_USER        - SSH user (default: root)
+#   GRAFANA_USER    - Grafana admin user (default: admin)
+#   GRAFANA_PASS    - Grafana admin password (default: admin)
+#   GRAFANA_HOST    - Override Grafana host (default: auto-detect from target)
+#   PROMETHEUS_HOST - Host running central Prometheus (default: first target)
+#
+# Notes:
+#   - The Prometheus scrape config is REPLACED with all targets from this run.
+#     Always pass ALL hosts you want monitored, not just new ones.
+#   - Requires smartmontools >= 7.4 on target nodes for FARM log support.
 #
 # Prerequisites:
 #   - SSH root access to target hosts
@@ -26,9 +32,12 @@ SSH_USER="${SSH_USER:-root}"
 GRAFANA_USER="${GRAFANA_USER:-admin}"
 GRAFANA_PASS="${GRAFANA_PASS:-admin}"
 GRAFANA_HOST="${GRAFANA_HOST:-}"
+PROMETHEUS_HOST="${PROMETHEUS_HOST:-}"
 
 if [[ $# -eq 0 ]]; then
     echo "Usage: $0 <target_host> [target_host2] ..."
+    echo ""
+    echo "NOTE: Pass ALL monitored hosts each run (scrape config is replaced, not appended)."
     exit 1
 fi
 
@@ -42,21 +51,20 @@ for TARGET in "$@"; do
     echo "==> Deploying to ${TARGET}"
     echo "========================================"
 
+    echo "==> Ensuring smartmontools is installed..."
+    ssh "${SSH_USER}@${TARGET}" "command -v smartctl >/dev/null 2>&1 || { echo 'Installing smartmontools...'; dnf install -y smartmontools >/dev/null 2>&1 || apt-get install -y smartmontools >/dev/null 2>&1; }"
+
+    echo "==> Checking smartctl version..."
+    ssh "${SSH_USER}@${TARGET}" "smartctl --version | head -1"
+
     echo "==> Copying binary..."
     scp smartctl_exporter "${SSH_USER}@${TARGET}:/usr/bin/smartctl_exporter"
 
     echo "==> Installing systemd service..."
     scp systemd/smartctl_exporter.service "${SSH_USER}@${TARGET}:/etc/systemd/system/smartctl_exporter.service"
 
-    echo "==> Installing Prometheus scrape config..."
-    ssh "${SSH_USER}@${TARGET}" "mkdir -p /etc/prometheus/scrape_configs"
-    scp smartctl_exporter.yml "${SSH_USER}@${TARGET}:/etc/prometheus/scrape_configs/smartctl_exporter.yml"
-
     echo "==> Enabling and starting smartctl_exporter..."
     ssh "${SSH_USER}@${TARGET}" "systemctl daemon-reload && systemctl enable --now smartctl_exporter && systemctl restart smartctl_exporter"
-
-    echo "==> Restarting Prometheus (if installed)..."
-    ssh "${SSH_USER}@${TARGET}" "systemctl restart prometheus 2>/dev/null || true"
 
     # Check if Grafana is running on this node and import dashboard
     GRAFANA_TARGET="${GRAFANA_HOST:-$TARGET}"
@@ -75,6 +83,38 @@ for TARGET in "$@"; do
 
     echo "==> ${TARGET} done. Exporter at http://${TARGET}:9633/metrics"
 done
+
+# Update central Prometheus scrape config with all targets
+PROM_HOST="${PROMETHEUS_HOST:-$1}"
+echo ""
+echo "==> Updating Prometheus scrape config on ${PROM_HOST}..."
+
+# Check if Prometheus is installed on the target
+if ! ssh "${SSH_USER}@${PROM_HOST}" "systemctl list-unit-files prometheus.service >/dev/null 2>&1"; then
+    echo "    WARNING: Prometheus not found on ${PROM_HOST}, skipping scrape config."
+    echo ""
+    echo "==> Deployment complete! (Prometheus scrape config must be configured manually)"
+    exit 0
+fi
+
+# Build targets list from all deployed hosts
+TARGETS=""
+for TARGET in "$@"; do
+    if [[ -n "$TARGETS" ]]; then
+        TARGETS="${TARGETS}, "
+    fi
+    TARGETS="${TARGETS}'${TARGET}:9633'"
+done
+
+ssh "${SSH_USER}@${PROM_HOST}" "mkdir -p /etc/prometheus/scrape_configs && cat > /etc/prometheus/scrape_configs/smartctl_exporter.yml" <<EOF
+scrape_configs:
+  - job_name: 'smartctl'
+    static_configs:
+      - targets: [${TARGETS}]
+EOF
+
+echo "==> Restarting Prometheus on ${PROM_HOST}..."
+ssh "${SSH_USER}@${PROM_HOST}" "systemctl restart prometheus 2>/dev/null || true"
 
 echo ""
 echo "==> Deployment complete!"

--- a/deploy.sh
+++ b/deploy.sh
@@ -133,7 +133,7 @@ SMARTCTL_CHECK
         echo "==> Grafana detected on ${TARGET}, installing dashboard to /etc/grafana/dashboards/system/..."
         ssh "${SSH_USER}@${TARGET}" "mkdir -p /etc/grafana/dashboards/system"
         scp "${SCRIPT_DIR}/smartctl-farm-dashboard.json" "${SSH_USER}@${TARGET}:/etc/grafana/dashboards/system/smartctl-farm-dashboard.json"
-        ssh "${SSH_USER}@${TARGET}" "chown grafana:grafana /etc/grafana/dashboards/system/smartctl-farm-dashboard.json && chmod 640 /etc/grafana/dashboards/system/smartctl-farm-dashboard.json"
+        ssh "${SSH_USER}@${TARGET}" "chown grafana:grafana /etc/grafana/dashboards/system/smartctl-farm-dashboard.json && chmod 472 /etc/grafana/dashboards/system/smartctl-farm-dashboard.json"
         echo "    Dashboard installed."
     else
         echo "==> Grafana not running on ${TARGET}, skipping dashboard install."

--- a/deploy.sh
+++ b/deploy.sh
@@ -82,6 +82,17 @@ for TARGET in "$@"; do
     echo "==> Enabling and starting smartctl_exporter..."
     ssh "${SSH_USER}@${TARGET}" "systemctl daemon-reload && systemctl enable --now smartctl_exporter && systemctl restart smartctl_exporter"
 
+    echo "==> Opening port 9633/tcp..."
+    ssh "${SSH_USER}@${TARGET}" "
+        if command -v firewall-cmd >/dev/null 2>&1; then
+            firewall-cmd --permanent --add-port=9633/tcp && firewall-cmd --reload
+        elif command -v ufw >/dev/null 2>&1; then
+            ufw allow 9633/tcp
+        else
+            echo '    No firewall manager found, skipping.'
+        fi
+    "
+
     # Check if Grafana is running on this node and import dashboard
     GRAFANA_TARGET="${GRAFANA_HOST:-$TARGET}"
     if ssh "${SSH_USER}@${TARGET}" "systemctl is-active grafana-server >/dev/null 2>&1"; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -134,7 +134,7 @@ SMARTCTL_CHECK
         echo "==> Grafana detected on ${TARGET}, installing dashboard to /etc/grafana/dashboards/system/..."
         ssh "${SSH_USER}@${TARGET}" "mkdir -p /etc/grafana/dashboards/system"
         scp "${SCRIPT_DIR}/smartctl-farm-dashboard.json" "${SSH_USER}@${TARGET}:/etc/grafana/dashboards/system/smartctl-farm-dashboard.json"
-        ssh "${SSH_USER}@${TARGET}" "chown grafana:grafana /etc/grafana/dashboards/system/smartctl-farm-dashboard.json && chmod 472 /etc/grafana/dashboards/system/smartctl-farm-dashboard.json"
+        ssh "${SSH_USER}@${TARGET}" "chown 472:grafana /etc/grafana/dashboards/system/smartctl-farm-dashboard.json && chmod 644 /etc/grafana/dashboards/system/smartctl-farm-dashboard.json"
         echo "    Dashboard installed."
     else
         echo "==> Grafana not running on ${TARGET}, skipping dashboard install."

--- a/deploy.sh
+++ b/deploy.sh
@@ -66,7 +66,24 @@ for TARGET in "$@"; do
             MAJOR=$(echo "$SMARTCTL_VER" | cut -d. -f1)
             MINOR=$(echo "$SMARTCTL_VER" | cut -d. -f2)
             if [[ "$MAJOR" -lt 7 ]] || { [[ "$MAJOR" -eq 7 ]] && [[ "$MINOR" -lt 4 ]]; }; then
-                echo "    WARNING: smartmontools ${SMARTCTL_VER} still below 7.4. FARM log support requires >= 7.4."
+                echo "    Distro package too old (${SMARTCTL_VER}), building smartmontools 7.4 from source..."
+                # Install build dependencies
+                if command -v dnf >/dev/null 2>&1; then
+                    dnf install -y gcc gcc-c++ make automake tar gzip
+                elif command -v apt-get >/dev/null 2>&1; then
+                    apt-get update && apt-get install -y build-essential automake tar gzip
+                fi
+                cd /tmp
+                curl -sLO https://sourceforge.net/projects/smartmontools/files/smartmontools/7.4/smartmontools-7.4.tar.gz/download
+                mv download smartmontools-7.4.tar.gz
+                tar xzf smartmontools-7.4.tar.gz
+                cd smartmontools-7.4
+                ./configure --prefix=/usr --sysconfdir=/etc
+                make -j"$(nproc)"
+                make install
+                cd /tmp && rm -rf smartmontools-7.4 smartmontools-7.4.tar.gz
+                SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+' | head -1)
+                echo "    Built and installed smartmontools ${SMARTCTL_VER} from source."
             else
                 echo "    Updated to smartmontools ${SMARTCTL_VER}."
             fi
@@ -113,9 +130,10 @@ SMARTCTL_CHECK
 
     # Install dashboard via file provisioning if Grafana is on this node
     if ssh "${SSH_USER}@${TARGET}" "systemctl is-active grafana-server >/dev/null 2>&1"; then
-        echo "==> Grafana detected on ${TARGET}, installing dashboard to /etc/grafana/dashboards/..."
-        scp "${SCRIPT_DIR}/smartctl-farm-dashboard.json" "${SSH_USER}@${TARGET}:/etc/grafana/dashboards/smartctl-farm-dashboard.json"
-        ssh "${SSH_USER}@${TARGET}" "chown grafana:grafana /etc/grafana/dashboards/smartctl-farm-dashboard.json"
+        echo "==> Grafana detected on ${TARGET}, installing dashboard to /etc/grafana/dashboards/system/..."
+        ssh "${SSH_USER}@${TARGET}" "mkdir -p /etc/grafana/dashboards/system"
+        scp "${SCRIPT_DIR}/smartctl-farm-dashboard.json" "${SSH_USER}@${TARGET}:/etc/grafana/dashboards/system/smartctl-farm-dashboard.json"
+        ssh "${SSH_USER}@${TARGET}" "chown grafana:grafana /etc/grafana/dashboards/system/smartctl-farm-dashboard.json && chmod 640 /etc/grafana/dashboards/system/smartctl-farm-dashboard.json"
         echo "    Dashboard installed."
     else
         echo "==> Grafana not running on ${TARGET}, skipping dashboard install."

--- a/deploy.sh
+++ b/deploy.sh
@@ -66,28 +66,9 @@ for TARGET in "$@"; do
             SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+' | head -1)
             MAJOR=$(echo "$SMARTCTL_VER" | cut -d. -f1)
             MINOR=$(echo "$SMARTCTL_VER" | cut -d. -f2)
-            if [[ "$MAJOR" -lt 7 ]] || { [[ "$MAJOR" -eq 7 ]] && [[ "$MINOR" -lt 4 ]]; }; then
-                echo "    Distro package too old (${SMARTCTL_VER}), building smartmontools 7.4 from source..."
-                # Install build dependencies
-                if command -v dnf >/dev/null 2>&1; then
-                    dnf install -y gcc gcc-c++ make automake tar gzip
-                elif command -v apt-get >/dev/null 2>&1; then
-                    apt-get update && apt-get install -y build-essential automake tar gzip
-                fi
-                cd /tmp
-                curl -sLO https://sourceforge.net/projects/smartmontools/files/smartmontools/7.4/smartmontools-7.4.tar.gz/download
-                mv download smartmontools-7.4.tar.gz
-                tar xzf smartmontools-7.4.tar.gz
-                cd smartmontools-7.4
-                ./configure --prefix=/usr --sysconfdir=/etc
-                make -j"$(nproc)"
-                make install
-                cd /tmp && rm -rf smartmontools-7.4 smartmontools-7.4.tar.gz
-                SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+' | head -1)
-                echo "    Built and installed smartmontools ${SMARTCTL_VER} from source."
-            else
-                echo "    Updated to smartmontools ${SMARTCTL_VER}."
-            fi
+
+            echo "    Updated to smartmontools ${SMARTCTL_VER}."
+ 
         else
             echo "    smartmontools ${SMARTCTL_VER} OK."
         fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,6 +37,7 @@ fi
 
 echo "==> Building smartctl_exporter (static)..."
 cd "$SCRIPT_DIR"
+go mod tidy
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o smartctl_exporter .
 
 for TARGET in "$@"; do

--- a/deploy.sh
+++ b/deploy.sh
@@ -52,7 +52,7 @@ for TARGET in "$@"; do
             dnf install -y smartmontools 2>/dev/null || apt-get install -y smartmontools 2>/dev/null
         fi
         # Check version and update if below 7.4
-        SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+')
+        SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+' | head -1)
         MAJOR=$(echo "$SMARTCTL_VER" | cut -d. -f1)
         MINOR=$(echo "$SMARTCTL_VER" | cut -d. -f2)
         if [[ "$MAJOR" -lt 7 ]] || { [[ "$MAJOR" -eq 7 ]] && [[ "$MINOR" -lt 4 ]]; }; then
@@ -62,7 +62,7 @@ for TARGET in "$@"; do
             elif command -v apt-get >/dev/null 2>&1; then
                 apt-get update && apt-get install -y --only-upgrade smartmontools
             fi
-            SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+')
+            SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+' | head -1)
             MAJOR=$(echo "$SMARTCTL_VER" | cut -d. -f1)
             MINOR=$(echo "$SMARTCTL_VER" | cut -d. -f2)
             if [[ "$MAJOR" -lt 7 ]] || { [[ "$MAJOR" -eq 7 ]] && [[ "$MINOR" -lt 4 ]]; }; then
@@ -203,7 +203,7 @@ else:
 
 with open(cfg, 'w') as f:
     f.write(content)
-PYEOFq
+PYEOF
 fi
 
 echo "==> Restarting Prometheus on ${PROM_HOST}..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,9 +12,6 @@ set -euo pipefail
 #
 # Environment variables:
 #   SSH_USER        - SSH user (default: root)
-#   GRAFANA_USER    - Grafana admin user (default: admin)
-#   GRAFANA_PASS    - Grafana admin password (default: admin)
-#   GRAFANA_HOST    - Override Grafana host (default: auto-detect from target)
 #   PROMETHEUS_HOST - Host running central Prometheus (default: first target)
 #
 # Notes:
@@ -29,9 +26,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SSH_USER="${SSH_USER:-root}"
-GRAFANA_USER="${GRAFANA_USER:-admin}"
-GRAFANA_PASS="${GRAFANA_PASS:-admin}"
-GRAFANA_HOST="${GRAFANA_HOST:-}"
 PROMETHEUS_HOST="${PROMETHEUS_HOST:-}"
 
 if [[ $# -eq 0 ]]; then
@@ -117,31 +111,14 @@ SMARTCTL_CHECK
         fi
     "
 
-    # Check if Grafana is running on this node and import dashboard
-    GRAFANA_TARGET="${GRAFANA_HOST:-$TARGET}"
+    # Install dashboard via file provisioning if Grafana is on this node
     if ssh "${SSH_USER}@${TARGET}" "systemctl is-active grafana-server >/dev/null 2>&1"; then
-        echo "==> Grafana detected on ${TARGET}, importing dashboard..."
-        sleep 5
-        # Import dashboard with instance regex cleared (we use IPs, not localhost)
-        python3 -c "
-import sys, json
-with open('${SCRIPT_DIR}/smartctl-farm-dashboard.json') as f:
-    d = json.load(f)
-for var in d.get('dashboard', d).get('templating', {}).get('list', []):
-    if var.get('name') == 'instance':
-        var['regex'] = ''
-d.setdefault('overwrite', True)
-if 'dashboard' in d:
-    d['dashboard']['id'] = None
-print(json.dumps(d))
-" | curl -sf -u "${GRAFANA_USER}:${GRAFANA_PASS}" \
-            -X POST -H "Content-Type: application/json" \
-            "http://${GRAFANA_TARGET}:3000/api/dashboards/db" \
-            -d @- \
-            && echo "    Dashboard imported." \
-            || echo "    WARNING: Dashboard import failed."
+        echo "==> Grafana detected on ${TARGET}, installing dashboard to /etc/grafana/dashboards/..."
+        scp "${SCRIPT_DIR}/smartctl-farm-dashboard.json" "${SSH_USER}@${TARGET}:/etc/grafana/dashboards/smartctl-farm-dashboard.json"
+        ssh "${SSH_USER}@${TARGET}" "chown grafana:grafana /etc/grafana/dashboards/smartctl-farm-dashboard.json"
+        echo "    Dashboard installed."
     else
-        echo "==> Grafana not running on ${TARGET}, skipping dashboard import."
+        echo "==> Grafana not running on ${TARGET}, skipping dashboard install."
     fi
 
     echo "==> ${TARGET} done. Exporter at http://${TARGET}:9633/metrics"

--- a/deploy.sh
+++ b/deploy.sh
@@ -51,11 +51,35 @@ for TARGET in "$@"; do
     echo "==> Deploying to ${TARGET}"
     echo "========================================"
 
-    echo "==> Ensuring smartmontools is installed..."
-    ssh "${SSH_USER}@${TARGET}" "command -v smartctl >/dev/null 2>&1 || { echo 'Installing smartmontools...'; dnf install -y smartmontools >/dev/null 2>&1 || apt-get install -y smartmontools >/dev/null 2>&1; }"
-
-    echo "==> Checking smartctl version..."
-    ssh "${SSH_USER}@${TARGET}" "smartctl --version | head -1"
+    echo "==> Ensuring smartmontools >= 7.4 is installed..."
+    ssh "${SSH_USER}@${TARGET}" bash -s <<'SMARTCTL_CHECK'
+        if ! command -v smartctl >/dev/null 2>&1; then
+            echo "    Installing smartmontools..."
+            dnf install -y smartmontools 2>/dev/null || apt-get install -y smartmontools 2>/dev/null
+        fi
+        # Check version and update if below 7.4
+        SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+')
+        MAJOR=$(echo "$SMARTCTL_VER" | cut -d. -f1)
+        MINOR=$(echo "$SMARTCTL_VER" | cut -d. -f2)
+        if [[ "$MAJOR" -lt 7 ]] || { [[ "$MAJOR" -eq 7 ]] && [[ "$MINOR" -lt 4 ]]; }; then
+            echo "    smartmontools ${SMARTCTL_VER} is below 7.4, attempting update..."
+            if command -v dnf >/dev/null 2>&1; then
+                dnf update -y smartmontools
+            elif command -v apt-get >/dev/null 2>&1; then
+                apt-get update && apt-get install -y --only-upgrade smartmontools
+            fi
+            SMARTCTL_VER=$(smartctl --version | head -1 | grep -oP '\d+\.\d+')
+            MAJOR=$(echo "$SMARTCTL_VER" | cut -d. -f1)
+            MINOR=$(echo "$SMARTCTL_VER" | cut -d. -f2)
+            if [[ "$MAJOR" -lt 7 ]] || { [[ "$MAJOR" -eq 7 ]] && [[ "$MINOR" -lt 4 ]]; }; then
+                echo "    WARNING: smartmontools ${SMARTCTL_VER} still below 7.4. FARM log support requires >= 7.4."
+            else
+                echo "    Updated to smartmontools ${SMARTCTL_VER}."
+            fi
+        else
+            echo "    smartmontools ${SMARTCTL_VER} OK."
+        fi
+SMARTCTL_CHECK
 
     echo "==> Stopping existing service (if running)..."
     ssh "${SSH_USER}@${TARGET}" "systemctl stop smartctl_exporter 2>/dev/null || true"
@@ -202,7 +226,7 @@ else:
 
 with open(cfg, 'w') as f:
     f.write(content)
-PYEOF
+PYEOFq
 fi
 
 echo "==> Restarting Prometheus on ${PROM_HOST}..."

--- a/farm.go
+++ b/farm.go
@@ -1,0 +1,355 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tidwall/gjson"
+)
+
+// mineFarmLog collects Seagate FARM log metrics if present in the JSON.
+func (smart *SMARTctl) mineFarmLog() {
+	farmLog := smart.json.Get("seagate_farm_log")
+	if !farmLog.Exists() {
+		return
+	}
+	smart.logger.Debug("Collecting Seagate FARM log metrics", "device", smart.device.device)
+	smart.mineFarmWorkload(farmLog)
+	smart.mineFarmErrors(farmLog)
+	smart.mineFarmEnvironment(farmLog)
+	smart.mineFarmReliability(farmLog)
+}
+
+func (smart *SMARTctl) mineFarmWorkload(farmLog gjson.Result) {
+	workload := farmLog.Get("page_2_workload_statistics")
+	if !workload.Exists() {
+		return
+	}
+
+	if v := workload.Get("total_read_commands"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmWorkloadReadCommands,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := workload.Get("total_write_commands"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmWorkloadWriteCommands,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := workload.Get("logical_sectors_read"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmWorkloadLogicalSectorsRead,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := workload.Get("logical_sectors_written"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmWorkloadLogicalSectorsWritten,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+}
+
+func (smart *SMARTctl) mineFarmErrors(farmLog gjson.Result) {
+	errors := farmLog.Get("page_3_error_statistics")
+	if !errors.Exists() {
+		return
+	}
+
+	if v := errors.Get("number_of_unrecoverable_read_errors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorUnrecoverableRead,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("number_of_unrecoverable_write_errors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorUnrecoverableWrite,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("number_of_reallocated_sectors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorReallocatedSectors,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("number_of_reallocated_candidate_sectors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorReallocatedCandidates,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("total_crc_errors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorCRCErrors,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("command_time_out_count_total"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorCommandTimeouts,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+
+	// Per-head unrecoverable error metrics
+	smart.mineFarmErrorsByHead(errors)
+}
+
+func (smart *SMARTctl) mineFarmErrorsByHead(errors gjson.Result) {
+	errors.ForEach(func(key, value gjson.Result) bool {
+		keyStr := key.String()
+		if !strings.HasPrefix(keyStr, "cum_lifetime_unrecoverable_by_head_") {
+			return true
+		}
+		head := strings.TrimPrefix(keyStr, "cum_lifetime_unrecoverable_by_head_")
+		if !value.IsObject() {
+			return true
+		}
+		if v := value.Get("cum_lifetime_unrecoverable_read_repeating"); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmErrorUnrecoverableByHead,
+				prometheus.CounterValue,
+				v.Float(),
+				smart.device.device,
+				head,
+				"read_repeating",
+			)
+		}
+		if v := value.Get("cum_lifetime_unrecoverable_read_unique"); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmErrorUnrecoverableByHead,
+				prometheus.CounterValue,
+				v.Float(),
+				smart.device.device,
+				head,
+				"read_unique",
+			)
+		}
+		return true
+	})
+}
+
+func (smart *SMARTctl) mineFarmEnvironment(farmLog gjson.Result) {
+	env := farmLog.Get("page_4_environment_statistics")
+	if !env.Exists() {
+		return
+	}
+
+	tempFields := map[string]string{
+		"curent_temp":      "current",
+		"highest_temp":     "highest",
+		"lowest_temp":      "lowest",
+		"average_temp":     "average",
+		"average_long_temp": "average_long",
+		"highest_short_temp": "highest_short",
+		"lowest_short_temp":  "lowest_short",
+		"highest_long_temp":  "highest_long",
+		"lowest_long_temp":   "lowest_long",
+	}
+	for field, label := range tempFields {
+		if v := env.Get(field); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmEnvironmentTemperature,
+				prometheus.GaugeValue,
+				v.Float(),
+				smart.device.device,
+				label,
+			)
+		}
+	}
+
+	if v := env.Get("humidity"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmEnvironmentHumidity,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+
+	if v := env.Get("current_motor_power"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmEnvironmentMotorPower,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+
+	voltageFields12V := map[string]string{
+		"current_12v_in_mv": "current",
+		"minimum_12v_in_mv": "minimum",
+		"maximum_12v_in_mv": "maximum",
+	}
+	for field, label := range voltageFields12V {
+		if v := env.Get(field); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmEnvironment12V,
+				prometheus.GaugeValue,
+				v.Float(),
+				smart.device.device,
+				label,
+			)
+		}
+	}
+
+	voltageFields5V := map[string]string{
+		"current_5v_in_mv": "current",
+		"minimum_5v_in_mv": "minimum",
+		"maximum_5v_in_mv": "maximum",
+	}
+	for field, label := range voltageFields5V {
+		if v := env.Get(field); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmEnvironment5V,
+				prometheus.GaugeValue,
+				v.Float(),
+				smart.device.device,
+				label,
+			)
+		}
+	}
+}
+
+func (smart *SMARTctl) mineFarmReliability(farmLog gjson.Result) {
+	rel := farmLog.Get("page_5_reliability_statistics")
+	if !rel.Exists() {
+		return
+	}
+
+	if v := rel.Get("attr_error_rate_raw"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmReliabilityErrorRate,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := rel.Get("attr_seek_error_rate_raw"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmReliabilitySeekErrorRate,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := rel.Get("high_priority_unload_events"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmReliabilityHighPriorityUnloads,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := rel.Get("helium_presure_trip"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmReliabilityHeliumPressureTrip,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+
+	// Per-head reliability metrics
+	smart.mineFarmReliabilityByHead(rel)
+}
+
+func (smart *SMARTctl) mineFarmReliabilityByHead(rel gjson.Result) {
+	// Reallocated sectors by head
+	rel.ForEach(func(key, value gjson.Result) bool {
+		keyStr := key.String()
+
+		if strings.HasPrefix(keyStr, "number_of_reallocated_sectors_by_head_") {
+			head := strings.TrimPrefix(keyStr, "number_of_reallocated_sectors_by_head_")
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmReliabilityReallocatedByHead,
+				prometheus.GaugeValue,
+				value.Float(),
+				smart.device.device,
+				head,
+			)
+		} else if strings.HasPrefix(keyStr, "number_of_reallocation_candidate_sectors_by_head_") {
+			head := strings.TrimPrefix(keyStr, "number_of_reallocation_candidate_sectors_by_head_")
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmReliabilityCandidatesByHead,
+				prometheus.GaugeValue,
+				value.Float(),
+				smart.device.device,
+				head,
+			)
+		} else if strings.HasPrefix(keyStr, "mr_head_resistance_from_head_") {
+			head := strings.TrimPrefix(keyStr, "mr_head_resistance_from_head_")
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmReliabilityMRHeadResistanceByHead,
+				prometheus.GaugeValue,
+				value.Float(),
+				smart.device.device,
+				head,
+			)
+		}
+
+		return true
+	})
+
+	// Skip write detect by head — multiple types per head
+	headCount := smart.json.Get("seagate_farm_log.page_1_drive_information.number_of_heads").Int()
+	for i := int64(0); i < headCount; i++ {
+		head := fmt.Sprintf("%d", i)
+		skipTypes := map[string]string{
+			fmt.Sprintf("dvga_skip_write_detect_by_head_%d", i):                   "dvga",
+			fmt.Sprintf("rvga_skip_write_detect_by_head_%d", i):                   "rvga",
+			fmt.Sprintf("fvga_skip_write_detect_by_head_%d", i):                   "fvga",
+			fmt.Sprintf("skip_write_detect_threshold_exceeded_by_head_%d", i):     "threshold_exceeded",
+		}
+		for field, detectType := range skipTypes {
+			if v := rel.Get(field); v.Exists() {
+				smart.ch <- prometheus.MustNewConstMetric(
+					metricFarmReliabilitySkipWriteByHead,
+					prometheus.GaugeValue,
+					v.Float(),
+					smart.device.device,
+					head,
+					detectType,
+				)
+			}
+		}
+	}
+}

--- a/farm_test.go
+++ b/farm_test.go
@@ -30,7 +30,7 @@ func TestMineFarmLog(t *testing.T) {
 	json := gjson.Parse(string(jsonFile))
 	ch := make(chan prometheus.Metric, 1000)
 
-	smart := NewSMARTctl(slog.Default(), json, ch)
+	smart := NewSMARTctl(slog.Default(), json, ch, Device{})
 	smart.mineFarmLog()
 	close(ch)
 
@@ -83,7 +83,7 @@ func TestMineFarmLogAbsentKey(t *testing.T) {
 	json := gjson.Parse(`{"device": {"name": "/dev/sda", "type": "sat", "protocol": "ATA"}, "model_name": "WDC WD10EZEX"}`)
 	ch := make(chan prometheus.Metric, 100)
 
-	smart := NewSMARTctl(slog.Default(), json, ch)
+	smart := NewSMARTctl(slog.Default(), json, ch, Device{})
 	smart.mineFarmLog()
 	close(ch)
 

--- a/farm_test.go
+++ b/farm_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tidwall/gjson"
+)
+
+func TestMineFarmLog(t *testing.T) {
+	jsonFile, err := os.ReadFile("testdata/sat-Seagate_Exos_X18-ST12000NM000J-farm.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	json := gjson.Parse(string(jsonFile))
+	ch := make(chan prometheus.Metric, 1000)
+
+	smart := NewSMARTctl(slog.Default(), json, ch)
+	smart.mineFarmLog()
+	close(ch)
+
+	metrics := make(map[string][]prometheus.Metric)
+	for m := range ch {
+		metrics[m.Desc().String()] = append(metrics[m.Desc().String()], m)
+	}
+
+	// Verify workload metrics
+	assertMetricCount(t, metrics, metricFarmWorkloadReadCommands, 1)
+	assertMetricCount(t, metrics, metricFarmWorkloadWriteCommands, 1)
+	assertMetricCount(t, metrics, metricFarmWorkloadLogicalSectorsRead, 1)
+	assertMetricCount(t, metrics, metricFarmWorkloadLogicalSectorsWritten, 1)
+
+	// Verify error metrics
+	assertMetricCount(t, metrics, metricFarmErrorUnrecoverableRead, 1)
+	assertMetricCount(t, metrics, metricFarmErrorUnrecoverableWrite, 1)
+	assertMetricCount(t, metrics, metricFarmErrorReallocatedSectors, 1)
+	assertMetricCount(t, metrics, metricFarmErrorReallocatedCandidates, 1)
+	assertMetricCount(t, metrics, metricFarmErrorCRCErrors, 1)
+	assertMetricCount(t, metrics, metricFarmErrorCommandTimeouts, 1)
+
+	// Verify per-head error metrics: 16 heads * 2 types = 32
+	assertMetricCount(t, metrics, metricFarmErrorUnrecoverableByHead, 32)
+
+	// Verify environment metrics
+	assertMetricCount(t, metrics, metricFarmEnvironmentTemperature, 9)
+	assertMetricCount(t, metrics, metricFarmEnvironmentHumidity, 1)
+	assertMetricCount(t, metrics, metricFarmEnvironmentMotorPower, 1)
+	// 12V and 5V all have value 0 but still exist in JSON
+	assertMetricCount(t, metrics, metricFarmEnvironment12V, 3)
+	assertMetricCount(t, metrics, metricFarmEnvironment5V, 3)
+
+	// Verify reliability metrics
+	assertMetricCount(t, metrics, metricFarmReliabilityErrorRate, 1)
+	assertMetricCount(t, metrics, metricFarmReliabilitySeekErrorRate, 1)
+	assertMetricCount(t, metrics, metricFarmReliabilityHighPriorityUnloads, 1)
+	assertMetricCount(t, metrics, metricFarmReliabilityHeliumPressureTrip, 1)
+
+	// Per-head reliability: 16 heads each
+	assertMetricCount(t, metrics, metricFarmReliabilityReallocatedByHead, 16)
+	assertMetricCount(t, metrics, metricFarmReliabilityCandidatesByHead, 16)
+	assertMetricCount(t, metrics, metricFarmReliabilityMRHeadResistanceByHead, 16)
+	// Skip write: 16 heads * 4 types = 64
+	assertMetricCount(t, metrics, metricFarmReliabilitySkipWriteByHead, 64)
+}
+
+func TestMineFarmLogAbsentKey(t *testing.T) {
+	// Test that no FARM metrics are emitted when seagate_farm_log is missing
+	json := gjson.Parse(`{"device": {"name": "/dev/sda", "type": "sat", "protocol": "ATA"}, "model_name": "WDC WD10EZEX"}`)
+	ch := make(chan prometheus.Metric, 100)
+
+	smart := NewSMARTctl(slog.Default(), json, ch)
+	smart.mineFarmLog()
+	close(ch)
+
+	count := 0
+	for range ch {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 metrics for non-Seagate drive, got %d", count)
+	}
+}
+
+func assertMetricCount(t *testing.T, metrics map[string][]prometheus.Metric, desc *prometheus.Desc, expected int) {
+	t.Helper()
+	actual := len(metrics[desc.String()])
+	if actual != expected {
+		t.Errorf("metric %s: expected %d, got %d", desc, expected, actual)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/smartctl_exporter
 
-go 1.25.0
+go 1.25
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/main.go
+++ b/main.go
@@ -126,6 +126,9 @@ var (
 	smartctlPowerModeCheck = kingpin.Flag("smartctl.powermode-check",
 		"Whether or not to check powermode before fetching data",
 	).Default("standby").String()
+	smartctlFarmLog = kingpin.Flag("smartctl.farm-log",
+		"Collect Seagate FARM log metrics (requires smartmontools 7.4+)",
+	).Default("false").Bool()
 )
 
 // scanDevices uses smartctl to gather the list of available devices.

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -36,9 +37,10 @@ import (
 
 // Device
 type Device struct {
-	Name  string
-	Type  string
-	Label string
+	Name     string
+	Type     string
+	Label    string
+	VdevLabel string
 }
 
 func (d Device) String() string {
@@ -69,7 +71,7 @@ func (i *SMARTctlManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		json := readData(i.logger, device)
 		if json.Exists() {
 			info.SetJSON(json)
-			smart := NewSMARTctl(i.logger, json, ch)
+			smart := NewSMARTctl(i.logger, json, ch, device)
 			smart.Collect()
 		}
 	}
@@ -129,7 +131,24 @@ var (
 	smartctlFarmLog = kingpin.Flag("smartctl.farm-log",
 		"Collect Seagate FARM log metrics (requires smartmontools 7.4+)",
 	).Default("false").Bool()
+	smartctlVdevLabel = kingpin.Flag("smartctl.vdev-label",
+		"Use udev ID_VDEV (slot number) as device label instead of sdX",
+	).Default("false").Bool()
 )
+
+// lookupVdevLabel queries udev for the ID_VDEV property of a device.
+func lookupVdevLabel(logger *slog.Logger, deviceName string) string {
+	out, err := exec.Command("udevadm", "info", "--query=property", deviceName).Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "ID_VDEV=") {
+			return strings.TrimPrefix(line, "ID_VDEV=")
+		}
+	}
+	return ""
+}
 
 // scanDevices uses smartctl to gather the list of available devices.
 func scanDevices(logger *slog.Logger) []Device {
@@ -151,11 +170,22 @@ func scanDevices(logger *slog.Logger) []Device {
 		if filter.ignored(deviceLabel) {
 			logger.Info("Ignoring device", "name", deviceLabel)
 		} else {
-			logger.Info("Found device", "name", deviceLabel)
+			vdevLabel := ""
+			if *smartctlVdevLabel {
+				vdevLabel = lookupVdevLabel(logger, deviceName)
+				if vdevLabel != "" {
+					logger.Info("Found device", "name", deviceLabel, "vdev", vdevLabel)
+				} else {
+					logger.Info("Found device", "name", deviceLabel, "vdev", "(none)")
+				}
+			} else {
+				logger.Info("Found device", "name", deviceLabel)
+			}
 			device := Device{
-				Name:  deviceName,
-				Type:  deviceType,
-				Label: deviceLabel,
+				Name:      deviceName,
+				Type:      deviceType,
+				Label:     deviceLabel,
+				VdevLabel: vdevLabel,
 			}
 			scanDeviceResult = append(scanDeviceResult, device)
 		}

--- a/metrics.go
+++ b/metrics.go
@@ -354,4 +354,150 @@ var (
 		},
 		nil,
 	)
+
+	// Seagate FARM log metrics
+	metricFarmWorkloadReadCommands = prometheus.NewDesc(
+		"smartctl_device_farm_workload_read_commands_total",
+		"Seagate FARM total read commands",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmWorkloadWriteCommands = prometheus.NewDesc(
+		"smartctl_device_farm_workload_write_commands_total",
+		"Seagate FARM total write commands",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmWorkloadLogicalSectorsRead = prometheus.NewDesc(
+		"smartctl_device_farm_workload_logical_sectors_read_total",
+		"Seagate FARM logical sectors read",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmWorkloadLogicalSectorsWritten = prometheus.NewDesc(
+		"smartctl_device_farm_workload_logical_sectors_written_total",
+		"Seagate FARM logical sectors written",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorUnrecoverableRead = prometheus.NewDesc(
+		"smartctl_device_farm_error_unrecoverable_read_total",
+		"Seagate FARM unrecoverable read errors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorUnrecoverableWrite = prometheus.NewDesc(
+		"smartctl_device_farm_error_unrecoverable_write_total",
+		"Seagate FARM unrecoverable write errors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorReallocatedSectors = prometheus.NewDesc(
+		"smartctl_device_farm_error_reallocated_sectors",
+		"Seagate FARM reallocated sectors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorReallocatedCandidates = prometheus.NewDesc(
+		"smartctl_device_farm_error_reallocated_candidate_sectors",
+		"Seagate FARM reallocated candidate sectors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorCRCErrors = prometheus.NewDesc(
+		"smartctl_device_farm_error_crc_errors_total",
+		"Seagate FARM total CRC errors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorCommandTimeouts = prometheus.NewDesc(
+		"smartctl_device_farm_error_command_timeouts_total",
+		"Seagate FARM command timeout count",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmEnvironmentTemperature = prometheus.NewDesc(
+		"smartctl_device_farm_environment_temperature_celsius",
+		"Seagate FARM environment temperature",
+		[]string{"device", "temperature_type"},
+		nil,
+	)
+	metricFarmEnvironmentHumidity = prometheus.NewDesc(
+		"smartctl_device_farm_environment_humidity_percent",
+		"Seagate FARM environment humidity percentage",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmEnvironment12V = prometheus.NewDesc(
+		"smartctl_device_farm_environment_12v_millivolts",
+		"Seagate FARM 12V rail millivolts",
+		[]string{"device", "voltage_type"},
+		nil,
+	)
+	metricFarmEnvironment5V = prometheus.NewDesc(
+		"smartctl_device_farm_environment_5v_millivolts",
+		"Seagate FARM 5V rail millivolts",
+		[]string{"device", "voltage_type"},
+		nil,
+	)
+	metricFarmEnvironmentMotorPower = prometheus.NewDesc(
+		"smartctl_device_farm_environment_motor_power",
+		"Seagate FARM current motor power",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmReliabilityErrorRate = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_error_rate_raw",
+		"Seagate FARM error rate raw value",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmReliabilitySeekErrorRate = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_seek_error_rate_raw",
+		"Seagate FARM seek error rate raw value",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmReliabilityHighPriorityUnloads = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_high_priority_unload_events",
+		"Seagate FARM high priority unload events",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmReliabilityHeliumPressureTrip = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_helium_pressure_trip",
+		"Seagate FARM helium pressure trip count",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorUnrecoverableByHead = prometheus.NewDesc(
+		"smartctl_device_farm_error_unrecoverable_by_head",
+		"Seagate FARM per-head unrecoverable errors",
+		[]string{"device", "head", "error_type"},
+		nil,
+	)
+	metricFarmReliabilityReallocatedByHead = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_reallocated_sectors_by_head",
+		"Seagate FARM per-head reallocated sectors",
+		[]string{"device", "head"},
+		nil,
+	)
+	metricFarmReliabilityCandidatesByHead = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_reallocation_candidates_by_head",
+		"Seagate FARM per-head reallocation candidate sectors",
+		[]string{"device", "head"},
+		nil,
+	)
+	metricFarmReliabilitySkipWriteByHead = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_skip_write_detect_by_head",
+		"Seagate FARM per-head skip write detect count",
+		[]string{"device", "head", "detect_type"},
+		nil,
+	)
+	metricFarmReliabilityMRHeadResistanceByHead = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_mr_head_resistance_by_head",
+		"Seagate FARM per-head MR head resistance",
+		[]string{"device", "head"},
+		nil,
+	)
 )

--- a/readjson.go
+++ b/readjson.go
@@ -82,6 +82,10 @@ func readSMARTctl(logger *slog.Logger, device Device, wg *sync.WaitGroup) {
 	jsonOk := jsonIsOk(logger, json)
 	logger.Debug("Collected S.M.A.R.T. json data", "device", device, "duration", time.Since(start))
 	if rcOk && jsonOk {
+		if json.Get("device.name").String() == "" {
+			logger.Warn("Smartctl returned no device info, skipping cache", "device", device)
+			return
+		}
 		jsonCache.Store(device, JSONCache{JSON: json, LastCollect: time.Now()})
 	}
 }
@@ -114,11 +118,17 @@ func refreshAllDevices(logger *slog.Logger, devices []Device) {
 	}
 
 	var wg sync.WaitGroup
+	// Limit concurrent smartctl calls to avoid overwhelming the system
+	sem := make(chan struct{}, 8)
 	for _, device := range devices {
 		cacheValue, cacheOk := jsonCache.Load(device)
 		if !cacheOk || time.Now().After(cacheValue.(JSONCache).LastCollect.Add(*smartctlInterval)) {
 			wg.Add(1)
-			go readSMARTctl(logger, device, &wg)
+			sem <- struct{}{}
+			go func(d Device) {
+				defer func() { <-sem }()
+				readSMARTctl(logger, d, &wg)
+			}(device)
 		}
 	}
 	wg.Wait()
@@ -143,8 +153,15 @@ func resultCodeIsOk(logger *slog.Logger, device Device, SMARTCtlResult int64) bo
 	if SMARTCtlResult > 0 {
 		b := SMARTCtlResult
 		if (b & 1) != 0 {
-			logger.Error("Command line did not parse", "device", device)
-			result = false
+			if *smartctlFarmLog {
+				// When --log=farm is enabled, bit 0 may be set because the device
+				// does not support FARM logs. Downgrade to warning since SMART data
+				// is still valid.
+				logger.Warn("Command line did not parse (possibly unsupported --log=farm)", "device", device)
+			} else {
+				logger.Error("Command line did not parse", "device", device)
+				result = false
+			}
 		}
 		if (b & (1 << 1)) != 0 {
 			logger.Error("Device open failed, device did not return an IDENTIFY DEVICE structure, or device is in a low-power mode", "device", device)
@@ -179,7 +196,17 @@ func jsonIsOk(logger *slog.Logger, json gjson.Result) bool {
 	if messages.Exists() {
 		for _, message := range messages.Array() {
 			if message.Get("severity").String() == "error" {
-				logger.Error(message.Get("string").String())
+				msgStr := message.Get("string").String()
+				// FARM log errors are non-fatal: the device may not support FARM
+				// but still has valid SMART data
+				if *smartctlFarmLog &&
+					(strings.Contains(msgStr, "FARM") ||
+						strings.Contains(msgStr, "INVALID ARGUMENT TO -l: farm") ||
+						strings.Contains(msgStr, "VALID ARGUMENTS ARE:")) {
+					logger.Warn("FARM log not available", "msg", msgStr)
+					continue
+				}
+				logger.Error(msgStr)
 				return false
 			}
 		}

--- a/readjson.go
+++ b/readjson.go
@@ -64,7 +64,11 @@ func readFakeSMARTctl(logger *slog.Logger, device Device) gjson.Result {
 func readSMARTctl(logger *slog.Logger, device Device, wg *sync.WaitGroup) {
 	defer wg.Done()
 	start := time.Now()
-	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=" + *smartctlPowerModeCheck, "--format=brief", "--log=error", "--device=" + device.Type, device.Name}
+	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=" + *smartctlPowerModeCheck, "--format=brief", "--log=error"}
+	if *smartctlFarmLog {
+		smartctlArgs = append(smartctlArgs, "--log=farm")
+	}
+	smartctlArgs = append(smartctlArgs, "--device="+device.Type, device.Name)
 
 	logger.Debug("Calling smartctl with args", "args", strings.Join(smartctlArgs, " "))
 	out, err := exec.Command(*smartctlPath, smartctlArgs...).Output()

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -245,16 +245,16 @@
         "gridPos": {
           "x": 0,
           "y": 37,
-          "w": 12,
+          "w": 8,
           "h": 8
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=~\"$voltage_type\"}",
-            "legendFormat": "{{instance}} / {{device}} - {{voltage_type}}"
+            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"current\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
-        "title": "FARM 12V Rail (mV)",
+        "title": "FARM 12V Rail - Current (mV)",
         "type": "timeseries"
       },
       {
@@ -265,18 +265,106 @@
           }
         },
         "gridPos": {
-          "x": 12,
+          "x": 8,
           "y": 37,
-          "w": 12,
+          "w": 8,
           "h": 8
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=~\"$voltage_type\"}",
-            "legendFormat": "{{instance}} / {{device}} - {{voltage_type}}"
+            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"minimum\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
-        "title": "FARM 5V Rail Over Time",
+        "title": "FARM 12V Rail - Min (mV)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "mvolt"
+          }
+        },
+        "gridPos": {
+          "x": 16,
+          "y": 37,
+          "w": 8,
+          "h": 8
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"maximum\"}",
+            "legendFormat": "{{instance}} / {{device}}"
+          }
+        ],
+        "title": "FARM 12V Rail - Max (mV)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "mvolt"
+          }
+        },
+        "gridPos": {
+          "x": 0,
+          "y": 45,
+          "w": 8,
+          "h": 8
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"current\"}",
+            "legendFormat": "{{instance}} / {{device}}"
+          }
+        ],
+        "title": "FARM 5V Rail - Current (mV)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "mvolt"
+          }
+        },
+        "gridPos": {
+          "x": 8,
+          "y": 45,
+          "w": 8,
+          "h": 8
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"minimum\"}",
+            "legendFormat": "{{instance}} / {{device}}"
+          }
+        ],
+        "title": "FARM 5V Rail - Min (mV)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "mvolt"
+          }
+        },
+        "gridPos": {
+          "x": 16,
+          "y": 45,
+          "w": 8,
+          "h": 8
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"maximum\"}",
+            "legendFormat": "{{instance}} / {{device}}"
+          }
+        ],
+        "title": "FARM 5V Rail - Max (mV)",
         "type": "timeseries"
       },
       {
@@ -285,7 +373,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 45
+          "y": 53
         },
         "targets": [
           {
@@ -302,7 +390,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 45
+          "y": 53
         },
         "targets": [
           {
@@ -319,7 +407,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 53
+          "y": 61
         },
         "targets": [
           {
@@ -340,7 +428,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 53
+          "y": 61
         },
         "targets": [
           {
@@ -357,7 +445,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 61
+          "y": 69
         },
         "targets": [
           {

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -1,0 +1,314 @@
+{
+  "dashboard": {
+    "id": null,
+    "panels": [
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "celsius"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_temperature_celsius{device=~\"$device\", temperature_type=\"current\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM Temperature (Current)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "celsius"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_temperature_celsius{device=~\"$device\"}",
+            "legendFormat": "{{device}} - {{temperature_type}}"
+          }
+        ],
+        "title": "FARM Temperature (All Types)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "targets": [
+          {
+            "expr": "rate(smartctl_device_farm_workload_read_commands_total{device=~\"$device\"}[5m])",
+            "legendFormat": "{{device}} reads/s"
+          }
+        ],
+        "title": "FARM Workload - Read Commands",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "targets": [
+          {
+            "expr": "rate(smartctl_device_farm_workload_write_commands_total{device=~\"$device\"}[5m])",
+            "legendFormat": "{{device}} writes/s"
+          }
+        ],
+        "title": "FARM Workload - Write Commands",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 6,
+          "w": 8,
+          "x": 0,
+          "y": 16
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_error_reallocated_sectors{device=~\"$device\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM Reallocated Sectors",
+        "type": "stat"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 6,
+          "w": 8,
+          "x": 8,
+          "y": 16
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_error_crc_errors_total{device=~\"$device\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM CRC Errors",
+        "type": "stat"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 6,
+          "w": 8,
+          "x": 16,
+          "y": 16
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_error_command_timeouts_total{device=~\"$device\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM Command Timeouts",
+        "type": "stat"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 22
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_error_unrecoverable_read_total{device=~\"$device\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM Unrecoverable Read Errors",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 22
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_error_unrecoverable_write_total{device=~\"$device\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM Unrecoverable Write Errors",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "mvolt"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 30
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_12v_millivolts{device=~\"$device\"}",
+            "legendFormat": "{{device}} - {{voltage_type}}"
+          }
+        ],
+        "title": "FARM 12V Rail (mV)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 30
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_reliability_mr_head_resistance_by_head{device=~\"$device\"}",
+            "legendFormat": "{{device}} head {{head}}"
+          }
+        ],
+        "title": "FARM MR Head Resistance by Head",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 38
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_reliability_reallocated_sectors_by_head{device=~\"$device\"}",
+            "legendFormat": "{{device}} head {{head}}"
+          }
+        ],
+        "title": "FARM Reallocated Sectors by Head",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 38
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_reliability_error_rate_raw{device=~\"$device\"}",
+            "legendFormat": "{{device}} error_rate"
+          },
+          {
+            "expr": "smartctl_device_farm_reliability_seek_error_rate_raw{device=~\"$device\"}",
+            "legendFormat": "{{device}} seek_error_rate"
+          }
+        ],
+        "title": "FARM Reliability - Error Rate / Seek Error Rate",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 6,
+          "w": 12,
+          "x": 0,
+          "y": 46
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_reliability_high_priority_unload_events{device=~\"$device\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM High Priority Unload Events",
+        "type": "stat"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 6,
+          "w": 12,
+          "x": 12,
+          "y": 46
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_motor_power{device=~\"$device\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM Motor Power",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "1m",
+    "schemaVersion": 38,
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "Prometheus",
+          "includeAll": true,
+          "multi": true,
+          "name": "device",
+          "query": "label_values(smartctl_device_farm_environment_temperature_celsius, device)",
+          "refresh": 2,
+          "type": "query"
+        }
+      ]
+    },
+    "timezone": "browser",
+    "title": "Seagate FARM & SMART Metrics",
+    "uid": "smartctl-farm",
+    "version": 1
+  }
+}

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -190,7 +190,7 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\"}",
+            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=~\"$voltage_type\"}",
             "legendFormat": "{{instance}} / {{device}} - {{voltage_type}}"
           }
         ],
@@ -212,8 +212,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", voltage_type=\"current\"}",
-            "legendFormat": "{{instance}} / {{device}}"
+            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=~\"$voltage_type\"}",
+            "legendFormat": "{{instance}} / {{device}} - {{voltage_type}}"
           }
         ],
         "title": "FARM 5V Rail Over Time",
@@ -352,12 +352,27 @@
           "query": "label_values(smartctl_device_farm_environment_temperature_celsius, temperature_type)",
           "refresh": 2,
           "type": "query"
+        },
+        {
+          "name": "voltage_type",
+          "type": "query",
+          "datasource": "Prometheus",
+          "query": "label_values(smartctl_device_farm_environment_12v_millivolts, voltage_type)",
+          "refresh": 1,
+          "includeAll": true,
+          "multi": true,
+          "allValue": ".*",
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "sort": 1
         }
       ]
     },
     "timezone": "browser",
     "title": "Seagate FARM & SMART Metrics",
     "uid": "smartctl-farm",
-    "version": 6
+    "version": 7
   }
 }

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -39,7 +39,7 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_temperature_celsius{instance=~\"$instance\", device=~\"$device\"}",
+            "expr": "smartctl_device_farm_environment_temperature_celsius{instance=~\"$instance\", device=~\"$device\", temperature_type=~\"$temperature_type\"}",
             "legendFormat": "{{instance}} / {{device}} - {{temperature_type}}"
           }
         ],
@@ -324,6 +324,7 @@
           "name": "instance",
           "query": "label_values(smartctl_device_farm_environment_temperature_celsius, instance)",
           "refresh": 2,
+          "regex": "/^(?!localhost).*/",
           "type": "query"
         },
         {
@@ -338,12 +339,25 @@
           "query": "label_values(smartctl_device_farm_environment_temperature_celsius, device)",
           "refresh": 2,
           "type": "query"
+        },
+        {
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "Prometheus",
+          "includeAll": true,
+          "multi": true,
+          "name": "temperature_type",
+          "query": "label_values(smartctl_device_farm_environment_temperature_celsius, temperature_type)",
+          "refresh": 2,
+          "type": "query"
         }
       ]
     },
     "timezone": "browser",
     "title": "Seagate FARM & SMART Metrics",
     "uid": "smartctl-farm",
-    "version": 3
+    "version": 5
   }
 }

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -183,10 +183,10 @@
           }
         },
         "gridPos": {
-          "h": 8,
-          "w": 12,
           "x": 0,
-          "y": 30
+          "y": 30,
+          "w": 12,
+          "h": 8
         },
         "targets": [
           {
@@ -199,11 +199,33 @@
       },
       {
         "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "mvolt"
+          }
+        },
+        "gridPos": {
+          "x": 12,
+          "y": 30,
+          "w": 12,
+          "h": 8
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", voltage_type=\"current\"}",
+            "legendFormat": "{{instance}} / {{device}}"
+          }
+        ],
+        "title": "FARM 5V Rail Over Time",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
         "gridPos": {
           "h": 8,
           "w": 12,
-          "x": 12,
-          "y": 30
+          "x": 0,
+          "y": 38
         },
         "targets": [
           {
@@ -219,7 +241,7 @@
         "gridPos": {
           "h": 8,
           "w": 12,
-          "x": 0,
+          "x": 12,
           "y": 38
         },
         "targets": [
@@ -236,8 +258,8 @@
         "gridPos": {
           "h": 8,
           "w": 12,
-          "x": 12,
-          "y": 38
+          "x": 0,
+          "y": 46
         },
         "targets": [
           {
@@ -255,9 +277,9 @@
       {
         "datasource": "Prometheus",
         "gridPos": {
-          "h": 6,
+          "h": 8,
           "w": 12,
-          "x": 0,
+          "x": 12,
           "y": 46
         },
         "targets": [
@@ -272,10 +294,10 @@
       {
         "datasource": "Prometheus",
         "gridPos": {
-          "h": 6,
+          "h": 8,
           "w": 12,
-          "x": 12,
-          "y": 46
+          "x": 0,
+          "y": 54
         },
         "targets": [
           {
@@ -284,28 +306,6 @@
           }
         ],
         "title": "FARM Motor Power",
-        "type": "timeseries"
-      },
-      {
-        "datasource": "Prometheus",
-        "fieldConfig": {
-          "defaults": {
-            "unit": "mvolt"
-          }
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 24,
-          "x": 0,
-          "y": 52
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", voltage_type=\"current\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM 5V Rail Over Time",
         "type": "timeseries"
       }
     ],
@@ -358,6 +358,6 @@
     "timezone": "browser",
     "title": "Seagate FARM & SMART Metrics",
     "uid": "smartctl-farm",
-    "version": 5
+    "version": 6
   }
 }

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -17,8 +17,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_temperature_celsius{device=~\"$device\", temperature_type=\"current\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_environment_temperature_celsius{instance=~\"$instance\", device=~\"$device\", temperature_type=\"current\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM Temperature (Current)",
@@ -39,8 +39,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_temperature_celsius{device=~\"$device\"}",
-            "legendFormat": "{{device}} - {{temperature_type}}"
+            "expr": "smartctl_device_farm_environment_temperature_celsius{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}} - {{temperature_type}}"
           }
         ],
         "title": "FARM Temperature (All Types)",
@@ -61,8 +61,8 @@
         },
         "targets": [
           {
-            "expr": "rate(smartctl_device_farm_workload_read_commands_total{device=~\"$device\"}[5m])",
-            "legendFormat": "{{device}} reads/s"
+            "expr": "rate(smartctl_device_farm_workload_read_commands_total{instance=~\"$instance\", device=~\"$device\"}[5m])",
+            "legendFormat": "{{instance}} / {{device}} reads/s"
           }
         ],
         "title": "FARM Workload - Read Commands",
@@ -83,8 +83,8 @@
         },
         "targets": [
           {
-            "expr": "rate(smartctl_device_farm_workload_write_commands_total{device=~\"$device\"}[5m])",
-            "legendFormat": "{{device}} writes/s"
+            "expr": "rate(smartctl_device_farm_workload_write_commands_total{instance=~\"$instance\", device=~\"$device\"}[5m])",
+            "legendFormat": "{{instance}} / {{device}} writes/s"
           }
         ],
         "title": "FARM Workload - Write Commands",
@@ -100,8 +100,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_error_reallocated_sectors{device=~\"$device\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_error_reallocated_sectors{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM Reallocated Sectors",
@@ -117,8 +117,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_error_crc_errors_total{device=~\"$device\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_error_crc_errors_total{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM CRC Errors",
@@ -134,8 +134,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_error_command_timeouts_total{device=~\"$device\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_error_command_timeouts_total{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM Command Timeouts",
@@ -151,8 +151,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_error_unrecoverable_read_total{device=~\"$device\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_error_unrecoverable_read_total{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM Unrecoverable Read Errors",
@@ -168,8 +168,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_error_unrecoverable_write_total{device=~\"$device\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_error_unrecoverable_write_total{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM Unrecoverable Write Errors",
@@ -190,8 +190,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_12v_millivolts{device=~\"$device\"}",
-            "legendFormat": "{{device}} - {{voltage_type}}"
+            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}} - {{voltage_type}}"
           }
         ],
         "title": "FARM 12V Rail (mV)",
@@ -207,8 +207,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_reliability_mr_head_resistance_by_head{device=~\"$device\"}",
-            "legendFormat": "{{device}} head {{head}}"
+            "expr": "smartctl_device_farm_reliability_mr_head_resistance_by_head{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}} head {{head}}"
           }
         ],
         "title": "FARM MR Head Resistance by Head",
@@ -224,8 +224,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_reliability_reallocated_sectors_by_head{device=~\"$device\"}",
-            "legendFormat": "{{device}} head {{head}}"
+            "expr": "smartctl_device_farm_reliability_reallocated_sectors_by_head{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}} head {{head}}"
           }
         ],
         "title": "FARM Reallocated Sectors by Head",
@@ -241,12 +241,12 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_reliability_error_rate_raw{device=~\"$device\"}",
-            "legendFormat": "{{device}} error_rate"
+            "expr": "smartctl_device_farm_reliability_error_rate_raw{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}} error_rate"
           },
           {
-            "expr": "smartctl_device_farm_reliability_seek_error_rate_raw{device=~\"$device\"}",
-            "legendFormat": "{{device}} seek_error_rate"
+            "expr": "smartctl_device_farm_reliability_seek_error_rate_raw{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}} seek_error_rate"
           }
         ],
         "title": "FARM Reliability - Error Rate / Seek Error Rate",
@@ -262,8 +262,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_reliability_high_priority_unload_events{device=~\"$device\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_reliability_high_priority_unload_events{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM High Priority Unload Events",
@@ -279,8 +279,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_motor_power{device=~\"$device\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_environment_motor_power{instance=~\"$instance\", device=~\"$device\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM Motor Power",
@@ -301,8 +301,8 @@
         },
         "targets": [
           {
-            "expr": "smartctl_device_farm_environment_5v_millivolts{voltage_type=\"current\"}",
-            "legendFormat": "{{device}}"
+            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", voltage_type=\"current\"}",
+            "legendFormat": "{{instance}} / {{device}}"
           }
         ],
         "title": "FARM 5V Rail Over Time",
@@ -321,6 +321,19 @@
           "datasource": "Prometheus",
           "includeAll": true,
           "multi": true,
+          "name": "instance",
+          "query": "label_values(smartctl_device_farm_environment_temperature_celsius, instance)",
+          "refresh": 2,
+          "type": "query"
+        },
+        {
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "Prometheus",
+          "includeAll": true,
+          "multi": true,
           "name": "device",
           "query": "label_values(smartctl_device_farm_environment_temperature_celsius, device)",
           "refresh": 2,
@@ -331,6 +344,6 @@
     "timezone": "browser",
     "title": "Seagate FARM & SMART Metrics",
     "uid": "smartctl-farm",
-    "version": 2
+    "version": 3
   }
 }

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -324,7 +324,7 @@
           "name": "instance",
           "query": "label_values(smartctl_device_farm_environment_temperature_celsius, instance)",
           "refresh": 2,
-          "regex": "/^(?!localhost).*/",
+          "regex": "",
           "type": "query"
         },
         {

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -285,6 +285,28 @@
         ],
         "title": "FARM Motor Power",
         "type": "timeseries"
+      },
+      {
+        "datasource": "Prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "mvolt"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 52
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device_farm_environment_5v_millivolts{voltage_type=\"current\"}",
+            "legendFormat": "{{device}}"
+          }
+        ],
+        "title": "FARM 5V Rail Over Time",
+        "type": "timeseries"
       }
     ],
     "refresh": "1m",
@@ -309,6 +331,6 @@
     "timezone": "browser",
     "title": "Seagate FARM & SMART Metrics",
     "uid": "smartctl-farm",
-    "version": 1
+    "version": 2
   }
 }

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -4,6 +4,66 @@
     "panels": [
       {
         "datasource": "Prometheus",
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "targets": [
+          {
+            "expr": "smartctl_device{instance=~\"$instance\", device=~\"$device\"}",
+            "format": "table",
+            "instant": true,
+            "legendFormat": ""
+          }
+        ],
+        "title": "Device Inventory (Slot / Device)",
+        "type": "table",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true,
+                "Value": true,
+                "__name__": true,
+                "job": true,
+                "ata_version": true,
+                "sata_version": true,
+                "form_factor": true,
+                "scsi_vendor": true,
+                "scsi_product": true,
+                "scsi_revision": true,
+                "scsi_version": true,
+                "ata_additional_product_id": true
+              },
+              "indexByName": {
+                "device": 0,
+                "instance": 1,
+                "model_family": 2,
+                "model_name": 3,
+                "serial_number": 4,
+                "firmware_version": 5,
+                "interface": 6,
+                "protocol": 7
+              },
+              "renameByName": {
+                "device": "Slot / Device",
+                "instance": "Instance",
+                "model_name": "Model",
+                "serial_number": "Serial",
+                "model_family": "Family",
+                "firmware_version": "Firmware",
+                "interface": "Interface",
+                "protocol": "Protocol"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "unit": "celsius"
@@ -13,7 +73,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 0
+          "y": 7
         },
         "targets": [
           {
@@ -35,7 +95,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 0
+          "y": 7
         },
         "targets": [
           {
@@ -57,7 +117,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 8
+          "y": 15
         },
         "targets": [
           {
@@ -79,7 +139,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 8
+          "y": 15
         },
         "targets": [
           {
@@ -96,7 +156,7 @@
           "h": 6,
           "w": 8,
           "x": 0,
-          "y": 16
+          "y": 23
         },
         "targets": [
           {
@@ -113,7 +173,7 @@
           "h": 6,
           "w": 8,
           "x": 8,
-          "y": 16
+          "y": 23
         },
         "targets": [
           {
@@ -130,7 +190,7 @@
           "h": 6,
           "w": 8,
           "x": 16,
-          "y": 16
+          "y": 23
         },
         "targets": [
           {
@@ -147,7 +207,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 22
+          "y": 29
         },
         "targets": [
           {
@@ -164,7 +224,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 22
+          "y": 29
         },
         "targets": [
           {
@@ -184,7 +244,7 @@
         },
         "gridPos": {
           "x": 0,
-          "y": 30,
+          "y": 37,
           "w": 12,
           "h": 8
         },
@@ -206,7 +266,7 @@
         },
         "gridPos": {
           "x": 12,
-          "y": 30,
+          "y": 37,
           "w": 12,
           "h": 8
         },
@@ -225,7 +285,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 38
+          "y": 45
         },
         "targets": [
           {
@@ -242,7 +302,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 38
+          "y": 45
         },
         "targets": [
           {
@@ -259,7 +319,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 46
+          "y": 53
         },
         "targets": [
           {
@@ -280,7 +340,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 46
+          "y": 53
         },
         "targets": [
           {
@@ -297,7 +357,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 54
+          "y": 61
         },
         "targets": [
           {

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -3,7 +3,7 @@
     "id": null,
     "panels": [
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 1,
         "gridPos": {
           "h": 7,
@@ -82,7 +82,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 2,
         "fieldConfig": {
           "defaults": {
@@ -119,7 +119,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 3,
         "fieldConfig": {
           "defaults": {
@@ -156,7 +156,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 4,
         "fieldConfig": {
           "defaults": {
@@ -193,7 +193,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 5,
         "fieldConfig": {
           "defaults": {
@@ -230,7 +230,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 6,
         "gridPos": {
           "h": 6,
@@ -266,7 +266,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 7,
         "gridPos": {
           "h": 6,
@@ -302,7 +302,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 8,
         "gridPos": {
           "h": 6,
@@ -338,7 +338,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 9,
         "gridPos": {
           "h": 8,
@@ -374,7 +374,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 10,
         "gridPos": {
           "h": 8,
@@ -410,7 +410,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 11,
         "fieldConfig": {
           "defaults": {
@@ -447,7 +447,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 12,
         "fieldConfig": {
           "defaults": {
@@ -484,7 +484,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 13,
         "fieldConfig": {
           "defaults": {
@@ -521,7 +521,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 14,
         "fieldConfig": {
           "defaults": {
@@ -558,7 +558,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 15,
         "fieldConfig": {
           "defaults": {
@@ -595,7 +595,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 16,
         "fieldConfig": {
           "defaults": {
@@ -632,7 +632,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 17,
         "gridPos": {
           "h": 8,
@@ -668,7 +668,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 18,
         "gridPos": {
           "h": 8,
@@ -704,7 +704,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 19,
         "gridPos": {
           "h": 8,
@@ -744,7 +744,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 20,
         "gridPos": {
           "h": 8,
@@ -780,7 +780,7 @@
         }
       },
       {
-        "datasource": "Prometheus",
+        "datasource": null,
         "id": 21,
         "gridPos": {
           "h": 8,
@@ -825,7 +825,6 @@
             "text": "All",
             "value": "$__all"
           },
-          "datasource": "Prometheus",
           "includeAll": true,
           "multi": true,
           "name": "instance",
@@ -839,7 +838,6 @@
             "text": "All",
             "value": "$__all"
           },
-          "datasource": "Prometheus",
           "includeAll": true,
           "multi": true,
           "name": "device",
@@ -852,7 +850,6 @@
             "text": "All",
             "value": "$__all"
           },
-          "datasource": "Prometheus",
           "includeAll": true,
           "multi": true,
           "name": "temperature_type",
@@ -863,7 +860,6 @@
         {
           "name": "voltage_type",
           "type": "query",
-          "datasource": "Prometheus",
           "query": "label_values(smartctl_device_farm_environment_12v_millivolts, voltage_type)",
           "refresh": 1,
           "includeAll": true,

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -61,15 +61,47 @@
               }
             }
           }
-        ]
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
         "id": 2,
         "fieldConfig": {
           "defaults": {
-            "unit": "celsius"
-          }
+            "unit": "celsius",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "h": 8,
@@ -91,8 +123,22 @@
         "id": 3,
         "fieldConfig": {
           "defaults": {
-            "unit": "celsius"
-          }
+            "unit": "celsius",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "h": 8,
@@ -114,8 +160,22 @@
         "id": 4,
         "fieldConfig": {
           "defaults": {
-            "unit": "ops"
-          }
+            "unit": "ops",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "h": 8,
@@ -137,8 +197,22 @@
         "id": 5,
         "fieldConfig": {
           "defaults": {
-            "unit": "ops"
-          }
+            "unit": "ops",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "h": 8,
@@ -279,7 +353,25 @@
           }
         ],
         "title": "FARM Unrecoverable Read Errors",
-        "type": "timeseries"
+        "type": "timeseries",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
@@ -297,15 +389,47 @@
           }
         ],
         "title": "FARM Unrecoverable Write Errors",
-        "type": "timeseries"
+        "type": "timeseries",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
         "id": 11,
         "fieldConfig": {
           "defaults": {
-            "unit": "mvolt"
-          }
+            "unit": "mvolt",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "x": 0,
@@ -327,8 +451,22 @@
         "id": 12,
         "fieldConfig": {
           "defaults": {
-            "unit": "mvolt"
-          }
+            "unit": "mvolt",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "x": 8,
@@ -350,8 +488,22 @@
         "id": 13,
         "fieldConfig": {
           "defaults": {
-            "unit": "mvolt"
-          }
+            "unit": "mvolt",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "x": 16,
@@ -373,8 +525,22 @@
         "id": 14,
         "fieldConfig": {
           "defaults": {
-            "unit": "mvolt"
-          }
+            "unit": "mvolt",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "x": 0,
@@ -396,8 +562,22 @@
         "id": 15,
         "fieldConfig": {
           "defaults": {
-            "unit": "mvolt"
-          }
+            "unit": "mvolt",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "x": 8,
@@ -419,8 +599,22 @@
         "id": 16,
         "fieldConfig": {
           "defaults": {
-            "unit": "mvolt"
-          }
+            "unit": "mvolt",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
         },
         "gridPos": {
           "x": 16,
@@ -453,7 +647,25 @@
           }
         ],
         "title": "FARM MR Head Resistance by Head",
-        "type": "timeseries"
+        "type": "timeseries",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
@@ -471,7 +683,25 @@
           }
         ],
         "title": "FARM Reallocated Sectors by Head",
-        "type": "timeseries"
+        "type": "timeseries",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
@@ -493,7 +723,25 @@
           }
         ],
         "title": "FARM Reliability - Error Rate / Seek Error Rate",
-        "type": "timeseries"
+        "type": "timeseries",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
@@ -547,7 +795,25 @@
           }
         ],
         "title": "FARM Motor Power",
-        "type": "timeseries"
+        "type": "timeseries",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       }
     ],
     "refresh": "1m",

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -1,881 +1,879 @@
 {
-  "dashboard": {
-    "id": null,
-    "panels": [
-      {
-        "datasource": null,
-        "id": 1,
-        "gridPos": {
-          "h": 7,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device{instance=~\"$instance\", device=~\"$device\"}",
-            "format": "table",
-            "instant": true,
-            "legendFormat": ""
+  "id": null,
+  "panels": [
+    {
+      "datasource": null,
+      "id": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device{instance=~\"$instance\", device=~\"$device\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "title": "Device Inventory (Slot / Device)",
+      "type": "table",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true,
+              "ata_version": true,
+              "sata_version": true,
+              "form_factor": true,
+              "scsi_vendor": true,
+              "scsi_product": true,
+              "scsi_revision": true,
+              "scsi_version": true,
+              "ata_additional_product_id": true
+            },
+            "indexByName": {
+              "device": 0,
+              "instance": 1,
+              "model_family": 2,
+              "model_name": 3,
+              "serial_number": 4,
+              "firmware_version": 5,
+              "interface": 6,
+              "protocol": 7
+            },
+            "renameByName": {
+              "device": "Slot / Device",
+              "instance": "Instance",
+              "model_name": "Model",
+              "serial_number": "Serial",
+              "model_family": "Family",
+              "firmware_version": "Firmware",
+              "interface": "Interface",
+              "protocol": "Protocol"
+            }
           }
-        ],
-        "title": "Device Inventory (Slot / Device)",
-        "type": "table",
-        "transformations": [
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time": true,
-                "Value": true,
-                "__name__": true,
-                "job": true,
-                "ata_version": true,
-                "sata_version": true,
-                "form_factor": true,
-                "scsi_vendor": true,
-                "scsi_product": true,
-                "scsi_revision": true,
-                "scsi_version": true,
-                "ata_additional_product_id": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               },
-              "indexByName": {
-                "device": 0,
-                "instance": 1,
-                "model_family": 2,
-                "model_name": 3,
-                "serial_number": 4,
-                "firmware_version": 5,
-                "interface": 6,
-                "protocol": 7
-              },
-              "renameByName": {
-                "device": "Slot / Device",
-                "instance": "Instance",
-                "model_name": "Model",
-                "serial_number": "Serial",
-                "model_family": "Family",
-                "firmware_version": "Firmware",
-                "interface": "Interface",
-                "protocol": "Protocol"
+              {
+                "color": "red",
+                "value": 80
               }
-            }
+            ]
           }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 2,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "celsius",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
         },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 7
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_temperature_celsius{instance=~\"$instance\", device=~\"$device\", temperature_type=\"current\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM Temperature (Current)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 3,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "celsius",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 7
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_temperature_celsius{instance=~\"$instance\", device=~\"$device\", temperature_type=~\"$temperature_type\"}",
-            "legendFormat": "{{instance}} / {{device}} - {{temperature_type}}"
-          }
-        ],
-        "title": "FARM Temperature (All Types)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 4,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "ops",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 15
-        },
-        "targets": [
-          {
-            "expr": "rate(smartctl_device_farm_workload_read_commands_total{instance=~\"$instance\", device=~\"$device\"}[5m])",
-            "legendFormat": "{{instance}} / {{device}} reads/s"
-          }
-        ],
-        "title": "FARM Workload - Read Commands",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 5,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "ops",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 15
-        },
-        "targets": [
-          {
-            "expr": "rate(smartctl_device_farm_workload_write_commands_total{instance=~\"$instance\", device=~\"$device\"}[5m])",
-            "legendFormat": "{{instance}} / {{device}} writes/s"
-          }
-        ],
-        "title": "FARM Workload - Write Commands",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 6,
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 0,
-          "y": 23
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_error_reallocated_sectors{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM Reallocated Sectors",
-        "type": "stat",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 7,
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 8,
-          "y": 23
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_error_crc_errors_total{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM CRC Errors",
-        "type": "stat",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 8,
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 16,
-          "y": 23
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_error_command_timeouts_total{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM Command Timeouts",
-        "type": "stat",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 9,
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 29
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_error_unrecoverable_read_total{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM Unrecoverable Read Errors",
-        "type": "timeseries",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 10,
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 29
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_error_unrecoverable_write_total{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM Unrecoverable Write Errors",
-        "type": "timeseries",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 11,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "mvolt",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "x": 0,
-          "y": 37,
-          "w": 8,
-          "h": 8
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"current\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM 12V Rail - Current (mV)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 12,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "mvolt",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "x": 8,
-          "y": 37,
-          "w": 8,
-          "h": 8
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"minimum\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM 12V Rail - Min (mV)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 13,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "mvolt",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "x": 16,
-          "y": 37,
-          "w": 8,
-          "h": 8
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"maximum\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM 12V Rail - Max (mV)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 14,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "mvolt",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "x": 0,
-          "y": 45,
-          "w": 8,
-          "h": 8
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"current\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM 5V Rail - Current (mV)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 15,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "mvolt",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "x": 8,
-          "y": 45,
-          "w": 8,
-          "h": 8
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"minimum\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM 5V Rail - Min (mV)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 16,
-        "fieldConfig": {
-          "defaults": {
-            "unit": "mvolt",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "x": 16,
-          "y": 45,
-          "w": 8,
-          "h": 8
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"maximum\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM 5V Rail - Max (mV)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": null,
-        "id": 17,
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 53
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_reliability_mr_head_resistance_by_head{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}} head {{head}}"
-          }
-        ],
-        "title": "FARM MR Head Resistance by Head",
-        "type": "timeseries",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 18,
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 53
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_reliability_reallocated_sectors_by_head{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}} head {{head}}"
-          }
-        ],
-        "title": "FARM Reallocated Sectors by Head",
-        "type": "timeseries",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 19,
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 61
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_reliability_error_rate_raw{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}} error_rate"
-          },
-          {
-            "expr": "smartctl_device_farm_reliability_seek_error_rate_raw{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}} seek_error_rate"
-          }
-        ],
-        "title": "FARM Reliability - Error Rate / Seek Error Rate",
-        "type": "timeseries",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 20,
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 61
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_reliability_high_priority_unload_events{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM High Priority Unload Events",
-        "type": "stat",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
-      },
-      {
-        "datasource": null,
-        "id": 21,
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 69
-        },
-        "targets": [
-          {
-            "expr": "smartctl_device_farm_environment_motor_power{instance=~\"$instance\", device=~\"$device\"}",
-            "legendFormat": "{{instance}} / {{device}}"
-          }
-        ],
-        "title": "FARM Motor Power",
-        "type": "timeseries",
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        }
+        "overrides": []
       }
-    ],
-    "refresh": "1m",
-    "schemaVersion": 38,
-    "templating": {
-      "list": [
-        {
-          "current": {
-            "text": "All",
-            "value": "$__all"
-          },
-          "includeAll": true,
-          "multi": true,
-          "name": "instance",
-          "query": "label_values(smartctl_device_farm_environment_temperature_celsius, instance)",
-          "refresh": 2,
-          "regex": "",
-          "type": "query"
-        },
-        {
-          "current": {
-            "text": "All",
-            "value": "$__all"
-          },
-          "includeAll": true,
-          "multi": true,
-          "name": "device",
-          "query": "label_values(smartctl_device_farm_environment_temperature_celsius, device)",
-          "refresh": 2,
-          "type": "query"
-        },
-        {
-          "current": {
-            "text": "All",
-            "value": "$__all"
-          },
-          "includeAll": true,
-          "multi": true,
-          "name": "temperature_type",
-          "query": "label_values(smartctl_device_farm_environment_temperature_celsius, temperature_type)",
-          "refresh": 2,
-          "type": "query"
-        },
-        {
-          "name": "voltage_type",
-          "type": "query",
-          "query": "label_values(smartctl_device_farm_environment_12v_millivolts, voltage_type)",
-          "refresh": 1,
-          "includeAll": true,
-          "multi": true,
-          "allValue": ".*",
-          "current": {
-            "text": "All",
-            "value": "$__all"
-          },
-          "sort": 1
-        }
-      ]
     },
-    "timezone": "browser",
-    "title": "Seagate FARM & SMART Metrics",
-    "uid": "smartctl-farm",
-    "version": 7
-  }
+    {
+      "datasource": null,
+      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_temperature_celsius{instance=~\"$instance\", device=~\"$device\", temperature_type=\"current\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM Temperature (Current)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_temperature_celsius{instance=~\"$instance\", device=~\"$device\", temperature_type=~\"$temperature_type\"}",
+          "legendFormat": "{{instance}} / {{device}} - {{temperature_type}}"
+        }
+      ],
+      "title": "FARM Temperature (All Types)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "targets": [
+        {
+          "expr": "rate(smartctl_device_farm_workload_read_commands_total{instance=~\"$instance\", device=~\"$device\"}[5m])",
+          "legendFormat": "{{instance}} / {{device}} reads/s"
+        }
+      ],
+      "title": "FARM Workload - Read Commands",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "targets": [
+        {
+          "expr": "rate(smartctl_device_farm_workload_write_commands_total{instance=~\"$instance\", device=~\"$device\"}[5m])",
+          "legendFormat": "{{instance}} / {{device}} writes/s"
+        }
+      ],
+      "title": "FARM Workload - Write Commands",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 6,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_error_reallocated_sectors{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM Reallocated Sectors",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 7,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_error_crc_errors_total{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM CRC Errors",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 8,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_error_command_timeouts_total{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM Command Timeouts",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 9,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_error_unrecoverable_read_total{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM Unrecoverable Read Errors",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 10,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_error_unrecoverable_write_total{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM Unrecoverable Write Errors",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"current\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM 12V Rail - Current (mV)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 12,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"minimum\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM 12V Rail - Min (mV)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 13,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_12v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"maximum\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM 12V Rail - Max (mV)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 14,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 45,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"current\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM 5V Rail - Current (mV)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 15,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 45,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"minimum\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM 5V Rail - Min (mV)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 16,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 45,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_5v_millivolts{instance=~\"$instance\", device=~\"$device\", voltage_type=\"maximum\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM 5V Rail - Max (mV)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "id": 17,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_reliability_mr_head_resistance_by_head{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}} head {{head}}"
+        }
+      ],
+      "title": "FARM MR Head Resistance by Head",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 18,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_reliability_reallocated_sectors_by_head{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}} head {{head}}"
+        }
+      ],
+      "title": "FARM Reallocated Sectors by Head",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 19,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_reliability_error_rate_raw{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}} error_rate"
+        },
+        {
+          "expr": "smartctl_device_farm_reliability_seek_error_rate_raw{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}} seek_error_rate"
+        }
+      ],
+      "title": "FARM Reliability - Error Rate / Seek Error Rate",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 20,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_reliability_high_priority_unload_events{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM High Priority Unload Events",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": null,
+      "id": 21,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "targets": [
+        {
+          "expr": "smartctl_device_farm_environment_motor_power{instance=~\"$instance\", device=~\"$device\"}",
+          "legendFormat": "{{instance}} / {{device}}"
+        }
+      ],
+      "title": "FARM Motor Power",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "multi": true,
+        "name": "instance",
+        "query": "label_values(smartctl_device_farm_environment_temperature_celsius, instance)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "multi": true,
+        "name": "device",
+        "query": "label_values(smartctl_device_farm_environment_temperature_celsius, device)",
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "multi": true,
+        "name": "temperature_type",
+        "query": "label_values(smartctl_device_farm_environment_temperature_celsius, temperature_type)",
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "name": "voltage_type",
+        "type": "query",
+        "query": "label_values(smartctl_device_farm_environment_12v_millivolts, voltage_type)",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      }
+    ]
+  },
+  "timezone": "browser",
+  "title": "Seagate FARM & SMART Metrics",
+  "uid": "smartctl-farm",
+  "version": 7
 }

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -4,6 +4,7 @@
     "panels": [
       {
         "datasource": "Prometheus",
+        "id": 1,
         "gridPos": {
           "h": 7,
           "w": 24,
@@ -64,6 +65,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 2,
         "fieldConfig": {
           "defaults": {
             "unit": "celsius"
@@ -86,6 +88,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 3,
         "fieldConfig": {
           "defaults": {
             "unit": "celsius"
@@ -108,6 +111,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 4,
         "fieldConfig": {
           "defaults": {
             "unit": "ops"
@@ -130,6 +134,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 5,
         "fieldConfig": {
           "defaults": {
             "unit": "ops"
@@ -152,6 +157,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 6,
         "gridPos": {
           "h": 6,
           "w": 8,
@@ -169,6 +175,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 7,
         "gridPos": {
           "h": 6,
           "w": 8,
@@ -186,6 +193,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 8,
         "gridPos": {
           "h": 6,
           "w": 8,
@@ -203,6 +211,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 9,
         "gridPos": {
           "h": 8,
           "w": 12,
@@ -220,6 +229,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 10,
         "gridPos": {
           "h": 8,
           "w": 12,
@@ -237,6 +247,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 11,
         "fieldConfig": {
           "defaults": {
             "unit": "mvolt"
@@ -259,6 +270,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 12,
         "fieldConfig": {
           "defaults": {
             "unit": "mvolt"
@@ -281,6 +293,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 13,
         "fieldConfig": {
           "defaults": {
             "unit": "mvolt"
@@ -303,6 +316,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 14,
         "fieldConfig": {
           "defaults": {
             "unit": "mvolt"
@@ -325,6 +339,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 15,
         "fieldConfig": {
           "defaults": {
             "unit": "mvolt"
@@ -347,6 +362,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 16,
         "fieldConfig": {
           "defaults": {
             "unit": "mvolt"
@@ -369,6 +385,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 17,
         "gridPos": {
           "h": 8,
           "w": 12,
@@ -386,6 +403,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 18,
         "gridPos": {
           "h": 8,
           "w": 12,
@@ -403,6 +421,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 19,
         "gridPos": {
           "h": 8,
           "w": 12,
@@ -424,6 +443,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 20,
         "gridPos": {
           "h": 8,
           "w": 12,
@@ -441,6 +461,7 @@
       },
       {
         "datasource": "Prometheus",
+        "id": 21,
         "gridPos": {
           "h": 8,
           "w": 12,

--- a/smartctl-farm-dashboard.json
+++ b/smartctl-farm-dashboard.json
@@ -171,7 +171,25 @@
           }
         ],
         "title": "FARM Reallocated Sectors",
-        "type": "stat"
+        "type": "stat",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
@@ -189,7 +207,25 @@
           }
         ],
         "title": "FARM CRC Errors",
-        "type": "stat"
+        "type": "stat",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
@@ -207,7 +243,25 @@
           }
         ],
         "title": "FARM Command Timeouts",
-        "type": "stat"
+        "type": "stat",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",
@@ -457,7 +511,25 @@
           }
         ],
         "title": "FARM High Priority Unload Events",
-        "type": "stat"
+        "type": "stat",
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        }
       },
       {
         "datasource": "Prometheus",

--- a/smartctl.go
+++ b/smartctl.go
@@ -101,6 +101,7 @@ func (smart *SMARTctl) Collect() {
 	smart.mineDeviceSelfTestLog()
 	smart.mineDeviceERC()
 	smart.mineSmartStatus()
+	smart.mineFarmLog()
 
 	if smart.device.interface_ == "nvme" {
 		smart.mineNvmePercentageUsed()

--- a/smartctl.go
+++ b/smartctl.go
@@ -55,7 +55,7 @@ func buildDeviceLabel(inputName string, inputType string) string {
 }
 
 // NewSMARTctl is smartctl constructor
-func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Metric) SMARTctl {
+func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Metric, dev Device) SMARTctl {
 	var model_name string
 	if obj := json.Get("model_name"); obj.Exists() {
 		model_name = obj.String()
@@ -67,12 +67,17 @@ func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Me
 		model_name = "unknown"
 	}
 
+	deviceLabel := buildDeviceLabel(json.Get("device.name").String(), json.Get("device.type").String())
+	if dev.VdevLabel != "" {
+		deviceLabel = dev.VdevLabel
+	}
+
 	return SMARTctl{
 		ch:     ch,
 		json:   json,
 		logger: logger,
 		device: SMARTDevice{
-			device:     buildDeviceLabel(json.Get("device.name").String(), json.Get("device.type").String()),
+			device:     deviceLabel,
 			serial:     strings.TrimSpace(json.Get("serial_number").String()),
 			family:     strings.TrimSpace(GetStringIfExists(json, "model_family", "unknown")),
 			model:      strings.TrimSpace(model_name),

--- a/systemd/smartctl_exporter.service
+++ b/systemd/smartctl_exporter.service
@@ -5,7 +5,7 @@ After=network-online.target
 [Service]
 Type=simple
 PIDFile=/run/smartctl_exporter.pid
-ExecStart=/usr/bin/smartctl_exporter --smartctl.farm-log
+ExecStart=/usr/bin/smartctl_exporter --smartctl.farm-log --smartctl.vdev-label
 User=root
 Group=root
 SyslogIdentifier=smartctl_exporter

--- a/systemd/smartctl_exporter.service
+++ b/systemd/smartctl_exporter.service
@@ -5,7 +5,7 @@ After=network-online.target
 [Service]
 Type=simple
 PIDFile=/run/smartctl_exporter.pid
-ExecStart=/usr/bin/smartctl_exporter
+ExecStart=/usr/bin/smartctl_exporter --smartctl.farm-log
 User=root
 Group=root
 SyslogIdentifier=smartctl_exporter

--- a/testdata/sat-Seagate_Exos_X18-ST12000NM000J-farm.json
+++ b/testdata/sat-Seagate_Exos_X18-ST12000NM000J-farm.json
@@ -1,0 +1,410 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      5
+    ],
+    "pre_release": false,
+    "svn_revision": "5714",
+    "platform_info": "x86_64-linux-5.14.0-611.9.1.el9_7.x86_64",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "--json",
+      "--log=farm",
+      "/dev/sda"
+    ],
+    "drive_database_version": {
+      "string": "7.5/5706"
+    },
+    "exit_status": 0
+  },
+  "local_time": {
+    "time_t": 1779999109,
+    "asctime": "Thu May 28 17:11:49 2026 ADT"
+  },
+  "device": {
+    "name": "/dev/sda",
+    "info_name": "/dev/sda [SAT]",
+    "type": "sat",
+    "protocol": "ATA"
+  },
+  "serial_number": "ZJV0PMA6",
+  "model_name": "ST12000NM000J-2TV103",
+  "model_family": "Seagate Exos X18",
+  "seagate_farm_log": {
+    "page_0_log_header": {
+      "farm_log_version": [
+        2,
+        1
+      ],
+      "pages_supported": 6,
+      "log_size": 98304,
+      "page_size": 16384,
+      "heads_supported": 24,
+      "number_of_copies": 0,
+      "reason_for_frame_capture": 0
+    },
+    "page_1_drive_information": {
+      "serial_number": "ZJV0PMA6",
+      "world_wide_name": "0x5000c500b17b059f",
+      "device_interface": "SATA",
+      "device_capacity_in_sectors": 23437770752,
+      "physical_sector_size": 4096,
+      "logical_sector_size": 512,
+      "device_buffer_size": 268435456,
+      "number_of_heads": 16,
+      "form_factor": "3.5 inches",
+      "rotation_rate": 7200,
+      "firmware_rev": "SN02    ",
+      "poh": 31583,
+      "spoh": 452565969807,
+      "head_flight_hours": 452565954977,
+      "head_load_events": 23003,
+      "power_cycle_count": 114,
+      "reset_count": 663,
+      "spin_up_time": 11,
+      "time_to_ready": 0,
+      "time_held": 0,
+      "drive_recording_type": "UNKNOWN",
+      "max_number_for_reasign": 0,
+      "date_of_assembly": "",
+      "depopulation_head_mask": 0
+    },
+    "page_2_workload_statistics": {
+      "total_read_commands": 947966635,
+      "total_write_commands": 159262778,
+      "total_random_reads": 31745091,
+      "total_random_writes": 134590856,
+      "total_other_commands": 31931579,
+      "logical_sectors_written": 108391477992,
+      "logical_sectors_read": 465962064793,
+      "dither": 0,
+      "dither_random": 0,
+      "dither_sequential": 0,
+      "read_commands_by_radius_0_3": 0,
+      "read_commands_by_radius_3_25": 0,
+      "read_commands_by_radius_25_75": 0,
+      "read_commands_by_radius_75_100": 0,
+      "write_commands_by_radius_0_3": 0,
+      "write_commands_by_radius_3_25": 0,
+      "write_commands_by_radius_25_75": 0,
+      "write_commands_by_radius_75_100": 0
+    },
+    "page_3_error_statistics": {
+      "number_of_unrecoverable_read_errors": 0,
+      "number_of_unrecoverable_write_errors": 0,
+      "number_of_reallocated_sectors": 0,
+      "number_of_read_recovery_attempts": 0,
+      "number_of_mechanical_start_failures": 0,
+      "number_of_reallocated_candidate_sectors": 0,
+      "total_asr_events": 124,
+      "total_crc_errors": 36507,
+      "attr_spin_retry_count": 0,
+      "normal_spin_retry_count": 100,
+      "worst_spin_rretry_count": 100,
+      "number_of_ioedc_errors": 0,
+      "command_time_out_count_total": 76,
+      "command_time_out_over_5_seconds_count": 0,
+      "command_time_out_over_7_seconds_count": 0,
+      "total_flash_led": 0,
+      "index_flash_led": 0,
+      "uncorrectables": 0,
+      "cumulative_unrecoverable_read_erc": 0,
+      "total_flash_led_errors": 0,
+      "flash_led_event_0": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_7": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_6": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_5": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_4": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_3": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_2": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_1": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_0": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_1": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_2": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_3": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_4": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_5": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_6": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_7": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_8": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_9": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_10": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_11": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_12": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_13": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_14": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_15": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      }
+    },
+    "page_4_environment_statistics": {
+      "curent_temp": 25,
+      "highest_temp": 39,
+      "lowest_temp": 0,
+      "average_temp": 25,
+      "average_long_temp": 26,
+      "highest_short_temp": 38,
+      "lowest_short_temp": 15,
+      "highest_long_temp": 33,
+      "lowest_long_temp": 20,
+      "over_temp_time": 0,
+      "under_temp_time": 210,
+      "max_temp": 60,
+      "min_temp": 5,
+      "humidity": 120,
+      "current_motor_power": 3615,
+      "current_12v_in_mv": 0,
+      "minimum_12v_in_mv": 0,
+      "maximum_12v_in_mv": 0,
+      "current_5v_in_mv": 0,
+      "minimum_5v_in_mv": 0,
+      "maximum_5v_in_mv": 0,
+      "average_12v_power": 0,
+      "minimum_12v_power": 0,
+      "maximum_12v_power": 0,
+      "average_5v_power": 0,
+      "minimum_5v_power": 0,
+      "maximum_5v_power": 0
+    },
+    "page_5_reliability_statistics": {
+      "attr_error_rate_raw": 96007328,
+      "error_rate_normalized": 80,
+      "error_rate_worst": 64,
+      "attr_seek_error_rate_raw": 407955248,
+      "seek_error_rate_normalized": 86,
+      "seek_error_rate_worst": 60,
+      "high_priority_unload_events": 224,
+      "helium_presure_trip": 0,
+      "lbas_corrected_by_parity_sector": 0,
+      "dvga_skip_write_detect_by_head_0": 0,
+      "dvga_skip_write_detect_by_head_1": 0,
+      "dvga_skip_write_detect_by_head_2": 0,
+      "dvga_skip_write_detect_by_head_3": 0,
+      "dvga_skip_write_detect_by_head_4": 0,
+      "dvga_skip_write_detect_by_head_5": 0,
+      "dvga_skip_write_detect_by_head_6": 0,
+      "dvga_skip_write_detect_by_head_7": 0,
+      "dvga_skip_write_detect_by_head_8": 0,
+      "dvga_skip_write_detect_by_head_9": 0,
+      "dvga_skip_write_detect_by_head_10": 0,
+      "dvga_skip_write_detect_by_head_11": 0,
+      "dvga_skip_write_detect_by_head_12": 0,
+      "dvga_skip_write_detect_by_head_13": 0,
+      "dvga_skip_write_detect_by_head_14": 0,
+      "dvga_skip_write_detect_by_head_15": 0,
+      "rvga_skip_write_detect_by_head_0": 0,
+      "rvga_skip_write_detect_by_head_1": 0,
+      "rvga_skip_write_detect_by_head_2": 0,
+      "rvga_skip_write_detect_by_head_3": 0,
+      "rvga_skip_write_detect_by_head_4": 0,
+      "rvga_skip_write_detect_by_head_5": 0,
+      "rvga_skip_write_detect_by_head_6": 0,
+      "rvga_skip_write_detect_by_head_7": 0,
+      "rvga_skip_write_detect_by_head_8": 0,
+      "rvga_skip_write_detect_by_head_9": 0,
+      "rvga_skip_write_detect_by_head_10": 0,
+      "rvga_skip_write_detect_by_head_11": 0,
+      "rvga_skip_write_detect_by_head_12": 0,
+      "rvga_skip_write_detect_by_head_13": 0,
+      "rvga_skip_write_detect_by_head_14": 0,
+      "rvga_skip_write_detect_by_head_15": 0,
+      "fvga_skip_write_detect_by_head_0": 0,
+      "fvga_skip_write_detect_by_head_1": 0,
+      "fvga_skip_write_detect_by_head_2": 0,
+      "fvga_skip_write_detect_by_head_3": 0,
+      "fvga_skip_write_detect_by_head_4": 0,
+      "fvga_skip_write_detect_by_head_5": 0,
+      "fvga_skip_write_detect_by_head_6": 0,
+      "fvga_skip_write_detect_by_head_7": 0,
+      "fvga_skip_write_detect_by_head_8": 0,
+      "fvga_skip_write_detect_by_head_9": 0,
+      "fvga_skip_write_detect_by_head_10": 0,
+      "fvga_skip_write_detect_by_head_11": 0,
+      "fvga_skip_write_detect_by_head_12": 0,
+      "fvga_skip_write_detect_by_head_13": 0,
+      "fvga_skip_write_detect_by_head_14": 0,
+      "fvga_skip_write_detect_by_head_15": 0,
+      "skip_write_detect_threshold_exceeded_by_head_0": 0,
+      "skip_write_detect_threshold_exceeded_by_head_1": 0,
+      "skip_write_detect_threshold_exceeded_by_head_2": 0,
+      "skip_write_detect_threshold_exceeded_by_head_3": 0,
+      "skip_write_detect_threshold_exceeded_by_head_4": 0,
+      "skip_write_detect_threshold_exceeded_by_head_5": 0,
+      "skip_write_detect_threshold_exceeded_by_head_6": 0,
+      "skip_write_detect_threshold_exceeded_by_head_7": 0,
+      "skip_write_detect_threshold_exceeded_by_head_8": 0,
+      "skip_write_detect_threshold_exceeded_by_head_9": 0,
+      "skip_write_detect_threshold_exceeded_by_head_10": 0,
+      "skip_write_detect_threshold_exceeded_by_head_11": 0,
+      "skip_write_detect_threshold_exceeded_by_head_12": 0,
+      "skip_write_detect_threshold_exceeded_by_head_13": 0,
+      "skip_write_detect_threshold_exceeded_by_head_14": 0,
+      "skip_write_detect_threshold_exceeded_by_head_15": 0,
+      "write_workload_power_on_time_by_head_0": 0,
+      "write_workload_power_on_time_by_head_1": 0,
+      "write_workload_power_on_time_by_head_2": 0,
+      "write_workload_power_on_time_by_head_3": 0,
+      "write_workload_power_on_time_by_head_4": 0,
+      "write_workload_power_on_time_by_head_5": 0,
+      "write_workload_power_on_time_by_head_6": 0,
+      "write_workload_power_on_time_by_head_7": 0,
+      "write_workload_power_on_time_by_head_8": 0,
+      "write_workload_power_on_time_by_head_9": 0,
+      "write_workload_power_on_time_by_head_10": 0,
+      "write_workload_power_on_time_by_head_11": 0,
+      "write_workload_power_on_time_by_head_12": 0,
+      "write_workload_power_on_time_by_head_13": 0,
+      "write_workload_power_on_time_by_head_14": 0,
+      "write_workload_power_on_time_by_head_15": 0,
+      "mr_head_resistance_from_head_0": 452,
+      "mr_head_resistance_from_head_1": 373,
+      "mr_head_resistance_from_head_2": 443,
+      "mr_head_resistance_from_head_3": 375,
+      "mr_head_resistance_from_head_4": 356,
+      "mr_head_resistance_from_head_5": 348,
+      "mr_head_resistance_from_head_6": 415,
+      "mr_head_resistance_from_head_7": 417,
+      "mr_head_resistance_from_head_8": 407,
+      "mr_head_resistance_from_head_9": 606,
+      "mr_head_resistance_from_head_10": 370,
+      "mr_head_resistance_from_head_11": 444,
+      "mr_head_resistance_from_head_12": 475,
+      "mr_head_resistance_from_head_13": 404,
+      "mr_head_resistance_from_head_14": 550,
+      "mr_head_resistance_from_head_15": 439,
+      "second_mr_head_resistance_by_head_0": 0,
+      "second_mr_head_resistance_by_head_1": 0,
+      "second_mr_head_resistance_by_head_2": 0,
+      "second_mr_head_resistance_by_head_3": 0,
+      "second_mr_head_resistance_by_head_4": 0,
+      "second_mr_head_resistance_by_head_5": 0,
+      "second_mr_head_resistance_by_head_6": 0,
+      "second_mr_head_resistance_by_head_7": 0,
+      "second_mr_head_resistance_by_head_8": 0,
+      "second_mr_head_resistance_by_head_9": 0,
+      "second_mr_head_resistance_by_head_10": 0,
+      "second_mr_head_resistance_by_head_11": 0,
+      "second_mr_head_resistance_by_head_12": 0,
+      "second_mr_head_resistance_by_head_13": 0,
+      "second_mr_head_resistance_by_head_14": 0,
+      "second_mr_head_resistance_by_head_15": 0,
+      "number_of_reallocated_sectors_by_head_0": 0,
+      "number_of_reallocated_sectors_by_head_1": 0,
+      "number_of_reallocated_sectors_by_head_2": 0,
+      "number_of_reallocated_sectors_by_head_3": 0,
+      "number_of_reallocated_sectors_by_head_4": 0,
+      "number_of_reallocated_sectors_by_head_5": 0,
+      "number_of_reallocated_sectors_by_head_6": 0,
+      "number_of_reallocated_sectors_by_head_7": 0,
+      "number_of_reallocated_sectors_by_head_8": 0,
+      "number_of_reallocated_sectors_by_head_9": 0,
+      "number_of_reallocated_sectors_by_head_10": 0,
+      "number_of_reallocated_sectors_by_head_11": 0,
+      "number_of_reallocated_sectors_by_head_12": 0,
+      "number_of_reallocated_sectors_by_head_13": 0,
+      "number_of_reallocated_sectors_by_head_14": 0,
+      "number_of_reallocated_sectors_by_head_15": 0,
+      "number_of_reallocation_candidate_sectors_by_head_0": 0,
+      "number_of_reallocation_candidate_sectors_by_head_1": 0,
+      "number_of_reallocation_candidate_sectors_by_head_2": 0,
+      "number_of_reallocation_candidate_sectors_by_head_3": 0,
+      "number_of_reallocation_candidate_sectors_by_head_4": 0,
+      "number_of_reallocation_candidate_sectors_by_head_5": 0,
+      "number_of_reallocation_candidate_sectors_by_head_6": 0,
+      "number_of_reallocation_candidate_sectors_by_head_7": 0,
+      "number_of_reallocation_candidate_sectors_by_head_8": 0,
+      "number_of_reallocation_candidate_sectors_by_head_9": 0,
+      "number_of_reallocation_candidate_sectors_by_head_10": 0,
+      "number_of_reallocation_candidate_sectors_by_head_11": 0,
+      "number_of_reallocation_candidate_sectors_by_head_12": 0,
+      "number_of_reallocation_candidate_sectors_by_head_13": 0,
+      "number_of_reallocation_candidate_sectors_by_head_14": 0,
+      "number_of_reallocation_candidate_sectors_by_head_15": 0
+    },
+    "supported": true
+  }
+}


### PR DESCRIPTION
This PR adds Seagate FARM (Field Accessible Reliability Metrics) log support to smartctl_exporter, along with deployment tooling and a purpose-built Grafana dashboard.

### FARM Log Metrics

Parses Seagate FARM log data from `smartctl -j --log=farm` and exposes the following Prometheus metric families:

- **Environment**: temperature (current/min/max/highest), 12V and 5V rail voltage (current/min/max), motor power
- **Workload**: read/write command counters
- **Error tracking**: reallocated sectors, CRC errors, command timeouts, unrecoverable read/write errors
- **Reliability**: MR head resistance per head, reallocated sectors per head, error rate, seek error rate, high priority unload events

FARM log collection is enabled via the `--smartctl.farm-log` flag and handles errors gracefully with limited concurrency to avoid overloading storage controllers.

### vdev-label Support

Adds `--smartctl.vdev-label` flag that reads udev `ID_VDEV` properties to use ZFS vdev labels (e.g. enclosure slot identifiers) as the device label in metrics, making it easier to correlate metrics with physical disk locations.

### Grafana Dashboard

Includes a comprehensive smartctl-farm-dashboard.json with panels for:
- Device inventory table
- Temperature (current and all types)
- Read/write command rates
- Error counters (reallocated sectors, CRC errors, command timeouts)
- Unrecoverable read/write errors
- 12V and 5V voltage rails with separate current, min, and max charts
- Per-head MR resistance and reallocated sectors
- Error rate / seek error rate and high priority unload events
- Motor power

Template variables for instance, device, temperature type, and voltage type filtering.

### Deploy Script

deploy.sh automates end-to-end deployment to one or more target hosts:
- Builds a static binary (`CGO_ENABLED=0`)
- Installs smartmontools if missing, copies binary and systemd service
- Auto-detects `ID_VDEV` udev data and enables `--smartctl.vdev-label`
- Auto-detects non-standard `smartctl` paths
- Imports the Grafana dashboard via API if Grafana is running on the target
- Configures Prometheus scrape targets (supports both `scrape_config_files` and inline `prometheus.yml` styles)