### PR TITLE
Enable arm64 container image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64
+DOCKER_ARCHS ?= amd64 arm64
 DOCKER_REPO  ?= prometheuscommunity
 
 include Makefile.common


### PR DESCRIPTION
## Summary
- include arm64 in the Docker architectures built and published by the Prometheus common container workflow
- allow the published image manifest to include linux/arm64 instead of only linux/amd64