### PR TITLE
Add arm64 to DOCKER_ARCHS for multi-arch image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64
+DOCKER_ARCHS ?= amd64 arm64
 DOCKER_REPO  ?= prometheuscommunity
 
 include Makefile.common


### PR DESCRIPTION
## Description
The published Docker image on Docker Hub is currently `amd64`-only, even though `promu` already successfully cross-compiles the binary for `linux/arm64`. 

This PR simply adds `arm64` to `DOCKER_ARCHS` in the Makefile so that the published multi-arch Docker image includes it. This will allow the exporter to run natively on ARM64 nodes (such as Ampere Altra or Raspberry Pi clusters) without relying on slow QEMU emulation or failing with `exec format error`.

## Testing done
- Verified locally: Cross-compiled using `promu crossbuild` and successfully built the image natively on an ARM64 host.
- Verified architecture via `docker inspect`.
- The `smartctl_exporter` binary starts and runs correctly inside the ARM64 container.
