### PR TITLE
Monitoring mixin: dashboard + alerts

### DIFF
--- a/mixin/Makefile
+++ b/mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-style s
+OUTPUT_DIR := output
+
+all: fmt $(OUTPUT_DIR)/smartctl_alerts.yaml $(OUTPUT_DIR)/dashboards lint
+
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+$(OUTPUT_DIR)/smartctl_alerts.yaml: mixin.libsonnet config.libsonnet $(wildcard alerts/*)
+	@mkdir -p $(OUTPUT_DIR)
+	jsonnet -S alerts.jsonnet > $@
+
+$(OUTPUT_DIR)/dashboards: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p $(OUTPUT_DIR)
+	jsonnet -m $(OUTPUT_DIR) dashboards.jsonnet
+
+lint: $(OUTPUT_DIR)/smartctl_alerts.yaml
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	@if command -v promtool >/dev/null 2>&1; then \
+		promtool check rules $(OUTPUT_DIR)/smartctl_alerts.yaml; \
+	else \
+		echo "promtool not found, skipping rules check"; \
+	fi
+
+.PHONY: jb_install
+jb_install:
+	jb install
+
+clean:
+	rm -rf $(OUTPUT_DIR)

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -1,0 +1,57 @@
+# smartctl-mixin
+
+A Prometheus / Grafana [mixin](https://github.com/monitoring-mixins/docs) for the
+[`smartctl_exporter`](https://github.com/prometheus-community/smartctl_exporter).
+
+It packages reusable, configurable alerting rules and a Grafana dashboard
+describing SMART disk health across all scraped instances.
+
+**Simply download them** from the [pre-compiled output directory](./output/) or modify your own [config file](./config.libsonnet) and follow the build instructions.
+
+## Build
+
+Requires `jsonnet` and `jsonnetfmt`; `jb` for dependency management and
+`promtool` (optional) for rule validation are recommended:
+
+```
+go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+```
+
+Ensure `$(go env GOPATH)/bin` is on your `$PATH` (`~/go/bin` by default).
+
+This mixin currently has no external Jsonnet dependencies, so `jb install` is
+optional. If you add a `jsonnetfile.json` dependency (e.g. grafonnet), run:
+
+```
+jb install
+```
+
+Generate the Prometheus rule files and the Grafana dashboard:
+
+```
+make          # fmt + alerts + dashboards + lint
+# or individually:
+make output/smartctl_alerts.yaml
+make output/dashboards
+```
+
+`output/` will contain `smartctl_alerts.yaml` and `smartctl-overview.json`,
+ready to be loaded.
+
+## Alerting rules
+
+| alert | severity | trigger |
+| --- | --- | --- |
+| `SmartDeviceTemperatureWarning` | warning | avg temp > 60 °C (configurable) |
+| `SmartDeviceTemperatureCritical` | critical | max temp > 70 °C (configurable) |
+| `SmartDeviceTemperatureOverTripValue` | critical | temp exceeds drive trip value |
+| `SmartDeviceTemperatureNearingTripValue` | warning | temp > 80 % of trip value |
+| `SmartStatus` | critical | `smartctl_device_smart_status != 1` probe is reporting issues |
+| `SmartCriticalWarning` | critical | `smartctl_device_critical_warning > 0` |
+| `SmartMediaErrors` | critical | `smartctl_device_media_errors > 0` |
+| `SmartWearoutIndicator` | critical | available spare below threshold |
+| `SmartDeviceSSDWearingOut` | warning | SSD Media Wearout Indicator < 10 |
+| `SmartErrorLogs` | critical | `smartctl_device_error_log_count > 0` |
+

--- a/mixin/alerts.jsonnet
+++ b/mixin/alerts.jsonnet
@@ -1,0 +1,1 @@
+std.manifestYamlDoc((import 'mixin.libsonnet').prometheusAlerts)

--- a/mixin/alerts/alerts.libsonnet
+++ b/mixin/alerts/alerts.libsonnet
@@ -1,0 +1,146 @@
+{
+  local c = $._config,
+  local sel = c.smartctlExporterSelector,
+
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'smartctl',
+        interval: '%s' % c.ruleEvaluationInterval,
+        rules: [
+          // ----------------------------------------------------------------
+          // Temperature
+          // ----------------------------------------------------------------
+          {
+            alert: 'SmartDeviceTemperatureWarning',
+            expr: |||
+              (
+                avg_over_time(smartctl_device_temperature{%(sel)s, temperature_type="current"}[%(temperatureAvgWindow)s])
+                  unless on (instance, device) smartctl_device_temperature{%(sel)s, temperature_type="drive_trip"}
+              ) > %(temperatureWarningThreshold)d
+            ||| % (c { sel: sel }),
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'warning' },
+            annotations: {
+              summary: 'SMART device temperature warning (instance {{ $labels.instance }})',
+              description: 'Device temperature warning on {{ $labels.instance }} drive {{ $labels.device }} over %(temperatureWarningThreshold)d°C. VALUE = {{ $value }}. LABELS = {{ $labels }}' % c,
+            },
+          },
+          {
+            alert: 'SmartDeviceTemperatureCritical',
+            expr: |||
+              (
+                max_over_time(smartctl_device_temperature{%(sel)s, temperature_type="current"}[%(temperatureAvgWindow)s])
+                  unless on (instance, device) smartctl_device_temperature{%(sel)s, temperature_type="drive_trip"}
+              ) > %(temperatureCriticalThreshold)d
+            ||| % (c { sel: sel }),
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'critical' },
+            annotations: {
+              summary: 'SMART device temperature critical (instance {{ $labels.instance }})',
+              description: 'Device temperature critical on {{ $labels.instance }} drive {{ $labels.device }} over %(temperatureCriticalThreshold)d°C. VALUE = {{ $value }}. LABELS = {{ $labels }}' % c,
+            },
+          },
+          {
+            alert: 'SmartDeviceTemperatureOverTripValue',
+            expr: |||
+              max_over_time(smartctl_device_temperature{%(sel)s, temperature_type="current"}[%(temperatureMaxWindow)s])
+                > on (device, instance) smartctl_device_temperature{%(sel)s, temperature_type="drive_trip"}
+            ||| % (c { sel: sel }),
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'critical' },
+            annotations: {
+              summary: 'SMART device temperature over trip value (instance {{ $labels.instance }})',
+              description: 'Device temperature over trip value on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}',
+            },
+          },
+          {
+            alert: 'SmartDeviceTemperatureNearingTripValue',
+            expr: |||
+              max_over_time(smartctl_device_temperature{%(sel)s, temperature_type="current"}[%(temperatureMaxWindow)s])
+                > on (device, instance) (smartctl_device_temperature{%(sel)s, temperature_type="drive_trip"} * %(temperatureNearingTripRatio)f)
+            ||| % (c { sel: sel }),
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'warning' },
+            annotations: {
+              summary: 'SMART device temperature nearing trip value (instance {{ $labels.instance }})',
+              description: 'Device temperature nearing trip value on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}',
+            },
+          },
+
+          // ----------------------------------------------------------------
+          // SMART status / critical warning / media errors
+          // ----------------------------------------------------------------
+          {
+            alert: 'SmartStatus',
+            expr: 'smartctl_device_smart_status{%(sel)s} != 1' % { sel: sel },
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'critical' },
+            annotations: {
+              summary: 'SMART status (instance {{ $labels.instance }})',
+              description: 'Device has a SMART status failure on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}',
+            },
+          },
+          {
+            alert: 'SmartCriticalWarning',
+            expr: 'smartctl_device_critical_warning{%(sel)s} > 0' % { sel: sel },
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'critical' },
+            annotations: {
+              summary: 'SMART critical warning (instance {{ $labels.instance }})',
+              description: 'Disk controller has critical warning on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}',
+            },
+          },
+          {
+            alert: 'SmartMediaErrors',
+            expr: 'smartctl_device_media_errors{%(sel)s} > 0' % { sel: sel },
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'critical' },
+            annotations: {
+              summary: 'SMART media errors (instance {{ $labels.instance }})',
+              description: 'Disk controller detected media errors on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}',
+            },
+          },
+
+          // ----------------------------------------------------------------
+          // Wear-out
+          // ----------------------------------------------------------------
+          {
+            alert: 'SmartWearoutIndicator',
+            expr: 'smartctl_device_available_spare{%(sel)s} < smartctl_device_available_spare_threshold{%(sel)s}' % { sel: sel },
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'critical' },
+            annotations: {
+              summary: 'SMART Wearout Indicator (instance {{ $labels.instance }})',
+              description: 'Device is wearing out on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}',
+            },
+          },
+          {
+            alert: 'SmartDeviceSSDWearingOut',
+            expr: 'smartctl_device_attribute{%(sel)s, attribute_name="Media_Wearout_Indicator", attribute_value_type="value"} < %(ssdWearoutThreshold)d' % { sel: sel, ssdWearoutThreshold: c.ssdWearoutThreshold },
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'warning' },
+            annotations: {
+              summary: 'SSD is wearing out (instance {{ $labels.instance }})',
+              description: 'Less than %(ssdWearoutThreshold)d%% lifetime remaining on SSD on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}' % c,
+            },
+          },
+
+          // ----------------------------------------------------------------
+          // Error logs
+          // ----------------------------------------------------------------
+          {
+            alert: 'SmartErrorLogs',
+            expr: 'smartctl_device_error_log_count{%(sel)s} > 0' % { sel: sel },
+            'for': '%s' % c.alertFor,
+            labels: { severity: 'critical' },
+            annotations: {
+              summary: 'SMART Warning Logs on {{ $labels.instance }}',
+              description: 'Device logged warnings on {{ $labels.instance }} (drive {{ $labels.device }}). VALUE = {{ $value }}. LABELS = {{ $labels }}',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -1,0 +1,37 @@
+{
+  _config+:: {
+    // Select the metrics coming from the smartctl_exporter. Adjust to match
+    // your scrape job, e.g. 'job="smartctl-exporter"'.
+    smartctlExporterSelector: 'job="smartctl"',
+
+    // Exclude virtual disks (e.g. CSI / iSCSI) from dashboards and rules. By default, filter out virtual disks created by LongHorn in K8s.
+    // Empty string means no filtering.
+    deviceModelExclusionSelector: 'model_name!="IET VIRTUAL-DISK"',
+
+    // Absolute temperature thresholds (°C) used by the temperature alerts
+    // that do not rely on the drive trip value.
+    temperatureWarningThreshold: 60,
+    temperatureCriticalThreshold: 70,
+
+    // Fraction of the drive trip value at which the "nearing trip"
+    // warning alert fires. 0.80 means 80% of the trip value is "nearing"
+    temperatureNearingTripRatio: 0.80,
+
+    // Remaining SSD lifetime (%) below which SmartDeviceSSDWearingOut alert fires.
+    ssdWearoutThreshold: 10,
+
+    // Look-back windows for temperature smoothing before evaluating the
+    // absolute thresholds.
+    temperatureAvgWindow: '5m',
+    temperatureMaxWindow: '10m',
+
+    // How long conditions must hold before alerting.
+    alertFor: '10m',
+
+    // Prometheus rule group evaluation interval.
+    ruleEvaluationInterval: '10m',
+
+    dashboardNamePrefix: 'smartctl / ',
+    dashboardTags: ['smartctl-mixin'],
+  },
+}

--- a/mixin/dashboards.jsonnet
+++ b/mixin/dashboards.jsonnet
@@ -1,0 +1,6 @@
+local dashboards = (import 'mixin.libsonnet').grafanaDashboards;
+
+{
+  [name]: dashboards[name]
+  for name in std.objectFields(dashboards)
+}

--- a/mixin/dashboards/smartctl.libsonnet
+++ b/mixin/dashboards/smartctl.libsonnet
@@ -1,0 +1,562 @@
+{
+  local c = $._config,
+  local sel = c.smartctlExporterSelector,
+  local excl = c.deviceModelExclusionSelector,
+  local ds = { type: 'prometheus', uid: '${DS_PROMETHEUS}' },
+
+  local prom(expr, legend, instant=false, ref='A') = {
+    datasource: ds,
+    editorMode: 'code',
+    exemplar: false,
+    expr: expr,
+    instant: instant,
+    legendFormat: legend,
+    range: !instant,
+    refId: ref,
+  },
+
+  local step(color, value=null) =
+    if value == null then { color: color } else { color: color, value: value },
+
+  local tsDefaults(unit, thresholds, max=null) = {
+    unit: unit,
+    color: { mode: 'palette-classic' },
+    max: if max == null then null else max,
+    thresholds: { mode: 'absolute', steps: thresholds },
+    custom: {
+      axisPlacement: 'auto',
+      drawStyle: 'line',
+      fillOpacity: 10,
+      lineInterpolation: 'smooth',
+      lineWidth: 1,
+      pointSize: 5,
+      showPoints: 'auto',
+      spanNulls: false,
+      stacking: { group: 'A', mode: 'none' },
+      thresholdsStyle: { mode: 'off' },
+    },
+  },
+
+  local tsOptions = {
+    legend: { calcs: ['lastNotNull', 'max'], displayMode: 'table', placement: 'bottom', showLegend: true },
+    tooltip: { mode: 'multi', sort: 'desc' },
+  },
+
+  local statDefaults(thresholds) = {
+    unit: 'short',
+    thresholds: { mode: 'absolute', steps: thresholds },
+  },
+
+  local tempQuery(instant=false, legend='{{instance}}/{{device}}', ref='Temperature') =
+    if excl == '' then
+      prom('sum by (instance, device)(smartctl_device_temperature{%(sel)s, instance=~"$instance", temperature_type="current"})' % { sel: sel }, legend, instant, ref)
+    else
+      prom('sum by (instance, device)(smartctl_device_temperature{%(sel)s, instance=~"$instance", temperature_type="current"}) and on(instance, device) smartctl_device{%(excl)s}' % { sel: sel, excl: excl }, legend, instant, ref),
+
+  local tempMedianQuery =
+    if excl == '' then
+      prom('quantile_over_time(0.5, sum by (instance, device) (smartctl_device_temperature{%(sel)s, instance=~"$instance", temperature_type="current"})[4w:1h])' % { sel: sel }, '{{instance}}/{{device}} median', true, 'Median temperature')
+    else
+      prom('quantile_over_time(0.5, sum by (instance, device) (smartctl_device_temperature{%(sel)s, instance=~"$instance", temperature_type="current"} and on(instance, device) smartctl_device{%(excl)s})[4w:1h])' % { sel: sel, excl: excl }, '{{instance}}/{{device}} median', true, 'Median temperature'),
+
+  local devicesQuery =
+    if excl == '' then
+      prom('smartctl_device{%(sel)s, instance=~"$instance"}' % { sel: sel }, '__auto', true, 'Devices') + { format: 'table' }
+    else
+      prom('smartctl_device{%(sel)s, instance=~"$instance", %(excl)s}' % { sel: sel, excl: excl }, '__auto', true, 'Devices') + { format: 'table' },
+
+  grafanaDashboards+:: {
+    'smartctl-overview.json': {
+      uid: 'smartctl-overview',
+      title: 'SMART Disk Health Monitoring',
+      tags: c.dashboardTags,
+      timezone: 'browser',
+      schemaVersion: 39,
+      version: 1,
+      refresh: '',
+      time: { from: 'now-12h', to: 'now' },
+      timepicker: {
+        refresh_intervals: ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'],
+      },
+      templating: {
+        list: [
+          {
+            name: 'DS_PROMETHEUS',
+            type: 'datasource',
+            query: 'prometheus',
+            label: 'Prometheus datasource',
+            current: { text: 'Prometheus', value: 'Prometheus' },
+            hide: 0,
+          },
+          {
+            name: 'instance',
+            type: 'query',
+            datasource: ds,
+            label: 'Instance',
+            query: 'label_values(smartctl_device_smart_status{%(sel)s}, instance)' % { sel: sel },
+            refresh: 1,
+            sort: 1,
+            multi: true,
+            includeAll: true,
+            current: { selected: false, text: 'All', value: '$__all' },
+            options: [],
+          },
+        ],
+      },
+      panels: [
+        // ----------------------------------------------------------------
+        // Header
+        // ----------------------------------------------------------------
+        {
+          id: 31,
+          type: 'text',
+          gridPos: { h: 4, w: 24, x: 0, y: 0 },
+          transparent: true,
+          options: {
+            mode: 'html',
+            content: '<div style="background: linear-gradient(135deg, #0d1117 0%, #1a1f2e 60%, #0f172a 100%); padding: 18px 28px; display: flex; align-items: center; gap: 22px; border-radius: 6px; border-left: 4px solid #3b82f6;">\n  <div>\n    <div style="color: #e2e8f0; margin: 0; font-size: 26px; font-weight: 700;">S.M.A.R.T. Disk Health Monitoring</div>\n    <div style="color: #64748b; margin: 5px 0 0; font-size: 13px;">Self-Monitoring, Analysis and Reporting Technology &mdash; real-time disk diagnostics &amp; predictive failure analysis</div>\n  </div>\n</div>',
+          },
+        },
+
+        // ----------------------------------------------------------------
+        // Overview row
+        // ----------------------------------------------------------------
+        {
+          id: 100,
+          type: 'row',
+          title: 'Overview',
+          gridPos: { h: 1, w: 24, x: 0, y: 4 },
+          collapsed: false,
+          panels: [],
+        },
+
+        // SMART probe
+        {
+          id: 19,
+          type: 'stat',
+          title: 'SMART probe',
+          description: 'Exit status from smartctl command for all devices selected. Indicates if metrics are collected properly.',
+          datasource: ds,
+          gridPos: { h: 3, w: 4, x: 0, y: 5 },
+          targets: [
+            prom('max(smartctl_device_smartctl_exit_status{%(sel)s, instance=~"$instance"} > 0 or vector(0))' % { sel: sel }, '__auto', false, 'Probe status'),
+          ],
+          fieldConfig: {
+            defaults: {
+              unit: 'short',
+              mappings: [
+                { type: 'value', options: { '0': { text: 'Running', index: 0 } } },
+                { type: 'range', options: { from: 1, to: null, result: { text: 'smartctl errors', index: 1 } } },
+              ],
+              thresholds: { mode: 'absolute', steps: [step('blue'), step('red', 1)] },
+            },
+            overrides: [],
+          },
+          options: {
+            colorMode: 'background',
+            graphMode: 'none',
+            reduceOptions: { calcs: ['max'], fields: '', values: false },
+            textMode: 'value',
+            wideLayout: true,
+          },
+        },
+
+        // Disk power-on time
+        {
+          id: 7,
+          type: 'stat',
+          title: 'Disk power-on time',
+          description: 'Number of seconds each disk has been powered on',
+          datasource: ds,
+          gridPos: { h: 7, w: 8, x: 4, y: 5 },
+          targets: [
+            prom('max by (instance, device)(smartctl_device_power_on_seconds{%(sel)s, instance=~"$instance"})' % { sel: sel }, '{{instance}} - {{device}}', true, 'On-time'),
+          ],
+          fieldConfig: {
+            defaults: {
+              unit: 's',
+              decimals: 1,
+              color: { fixedColor: 'text', mode: 'fixed' },
+              thresholds: { mode: 'absolute', steps: [step('text')] },
+            },
+            overrides: [],
+          },
+          options: {
+            colorMode: 'value',
+            graphMode: 'none',
+            reduceOptions: { calcs: ['lastNotNull'], fields: '', values: false },
+            textMode: 'auto',
+            wideLayout: true,
+          },
+        },
+
+        // Disk temperature
+        {
+          id: 6,
+          type: 'timeseries',
+          title: 'Disk temperature',
+          description: 'Disk temperatures over time for each device',
+          datasource: ds,
+          gridPos: { h: 9, w: 12, x: 12, y: 5 },
+          targets: [
+            tempQuery(false, '{{instance}}/{{device}}', 'Temperature'),
+          ],
+          fieldConfig: {
+            defaults: tsDefaults('celsius', [step('blue'), step('yellow', 50), step('red', 60)], 70) + {
+              custom+: { thresholdsStyle+: { mode: 'dashed' } },
+            },
+            overrides: [],
+          },
+          options: {
+            legend: {
+              calcs: ['lastNotNull', 'median'],
+              displayMode: 'list',
+              placement: 'bottom',
+              showLegend: true,
+            },
+            tooltip: { mode: 'multi', sort: 'desc' },
+          },
+        },
+
+        // Failed disks count
+        {
+          id: 20,
+          type: 'stat',
+          title: 'Failed disks count',
+          description: 'Number of disks with failing SMART status. Indicates disk death.',
+          datasource: ds,
+          gridPos: { h: 4, w: 4, x: 0, y: 8 },
+          targets: [
+            prom('count by (instance)(smartctl_device{%(sel)s, instance=~"$instance"}) - count by (instance)(smartctl_device_smart_status{%(sel)s, instance=~"$instance"} == 1)' % { sel: sel }, '__auto', true, 'Failing disks'),
+          ],
+          fieldConfig: {
+            defaults: statDefaults([step('transparent'), step('red', 1)]),
+            overrides: [],
+          },
+          options: {
+            colorMode: 'background',
+            graphMode: 'area',
+            reduceOptions: { calcs: ['lastNotNull'], fields: '', values: false },
+            textMode: 'value_and_name',
+            wideLayout: true,
+          },
+        },
+
+        // Devices in scope
+        {
+          id: 30,
+          type: 'table',
+          title: 'Devices in scope',
+          datasource: ds,
+          gridPos: { h: 9, w: 12, x: 0, y: 12 },
+          targets: [devicesQuery],
+          transformations: [
+            {
+              id: 'organize',
+              options: {
+                excludeByName: {
+                  Time: true,
+                  Value: true,
+                  __name__: true,
+                  ata_additional_product_id: true,
+                  ata_version: true,
+                  container: true,
+                  firmware_version: true,
+                  interface: true,
+                  job: true,
+                  k8s_cluster_name: true,
+                  model_family: true,
+                  namespace: true,
+                  pod: true,
+                  protocol: true,
+                  sata_version: true,
+                },
+                indexByName: {
+                  Time: 0,
+                  Value: 15,
+                  __name__: 1,
+                  ata_additional_product_id: 2,
+                  ata_version: 3,
+                  device: 5,
+                  firmware_version: 6,
+                  form_factor: 7,
+                  instance: 4,
+                  interface: 8,
+                  job: 9,
+                  model_family: 10,
+                  model_name: 11,
+                  protocol: 12,
+                  sata_version: 13,
+                  serial_number: 14,
+                },
+              },
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              color: { mode: 'thresholds' },
+              thresholds: { mode: 'absolute', steps: [step('green'), step('red', 80)] },
+              custom: { align: 'auto', filterable: true, cellOptions: { type: 'auto' } },
+            },
+            overrides: [],
+          },
+          options: { showHeader: true, cellHeight: 'sm', enablePagination: true },
+        },
+
+        // Prefailure checks below thresholds
+        {
+          id: 25,
+          type: 'table',
+          title: 'Prefailure checks below thresholds',
+          description: 'Detailed prefailured checks below thresholds. Indicates the disks are wearing out and need to be replaced with no immediate failure.',
+          datasource: ds,
+          gridPos: { h: 7, w: 12, x: 12, y: 14 },
+          targets: [
+            prom('max by(instance, device, attribute_name)(smartctl_device_attribute{%(sel)s, instance=~"$instance", attribute_flags_short=~"P.....", attribute_value_type="value"}) <= max by(instance, device, attribute_name)(smartctl_device_attribute{%(sel)s, instance=~"$instance", attribute_flags_short=~"P.....", attribute_value_type="thresh"})' % { sel: sel }, '__auto', true, 'Prefailure checks') + { format: 'table' },
+          ],
+          transformations: [
+            {
+              id: 'organize',
+              options: {
+                excludeByName: { Time: true, Value: true },
+                indexByName: { Time: 0, Value: 4, attribute_name: 3, device: 2, instance: 1 },
+                renameByName: { attribute_name: '' },
+              },
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              color: { fixedColor: 'yellow', mode: 'fixed' },
+              thresholds: { mode: 'absolute', steps: [step('transparent')] },
+              custom: { align: 'auto', filterable: true, cellOptions: { type: 'auto' } },
+            },
+            overrides: [
+              {
+                matcher: { id: 'byName', options: 'attribute_name' },
+                properties: [{ id: 'custom.cellOptions', value: { type: 'pill' } }],
+              },
+            ],
+          },
+          options: { showHeader: true, cellHeight: 'sm', enablePagination: true, frameIndex: 1, sortBy: [{ desc: false, displayName: 'attribute_id' }] },
+        },
+
+        // ----------------------------------------------------------------
+        // HDD / SSD row
+        // ----------------------------------------------------------------
+        {
+          id: 101,
+          type: 'row',
+          title: 'HDD / SSD',
+          gridPos: { h: 1, w: 24, x: 0, y: 21 },
+          collapsed: false,
+          panels: [],
+        },
+
+        // Failing HDDs
+        {
+          id: 26,
+          type: 'table',
+          title: 'Failing HDDs',
+          description: 'Disks with any error logs, unrecoverable/reallocated/pending sectors on HDD. Could indicate imminent failure or data corruption.',
+          datasource: ds,
+          gridPos: { h: 8, w: 6, x: 0, y: 22 },
+          targets: [
+            prom('sum by (instance, device)(max_over_time(smartctl_device_attribute{%(sel)s, instance=~"$instance", attribute_name=~"Offline_Uncorrectable|Current_Pending_Sector|Reallocated_Sector_Ct", attribute_value_type="raw"}[$__range])) > 0' % { sel: sel }, '{{instance}} - {{device}}', true, 'Failing HDD') + { format: 'table' },
+          ],
+          transformations: [
+            {
+              id: 'organize',
+              options: {
+                excludeByName: { Time: true, Value: true },
+                renameByName: { instance: 'Instance', device: 'Device' },
+              },
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              color: { mode: 'thresholds' },
+              thresholds: { mode: 'absolute', steps: [step('transparent'), step('red', 1)] },
+              custom: { align: 'auto', filterable: true, cellOptions: { type: 'auto' } },
+            },
+            overrides: [],
+          },
+          options: { showHeader: true, cellHeight: 'sm', enablePagination: true },
+        },
+
+        // SSD wearout indicator
+        {
+          id: 29,
+          type: 'gauge',
+          title: 'SSD wearout indicator',
+          description: 'Remaining life measured for SSDs',
+          datasource: ds,
+          gridPos: { h: 8, w: 6, x: 6, y: 22 },
+          targets: [
+            prom('smartctl_device_attribute{%(sel)s, instance=~"$instance", attribute_name="Media_Wearout_Indicator", attribute_value_type="value"}' % { sel: sel }, '{{instance}} - {{device}}', true, 'SSD wearout'),
+          ],
+          fieldConfig: {
+            defaults: {
+              unit: 'percent',
+              min: 0,
+              max: 100,
+              color: { mode: 'thresholds' },
+              thresholds: { mode: 'absolute', steps: [step('red'), step('yellow', 10), step('blue', 30)] },
+            },
+            overrides: [],
+          },
+          options: {
+            orientation: 'auto',
+            reduceOptions: { calcs: ['lastNotNull'], fields: '', values: false },
+            showThresholdLabels: false,
+            showThresholdMarkers: true,
+            textMode: 'auto',
+          },
+        },
+
+        // Offline uncorrectable sectors
+        {
+          id: 12,
+          type: 'stat',
+          title: 'Offline uncorrectable sectors',
+          description: 'Uncorrectable sectors. Any value > 0 indicates data loss or corruption risk',
+          datasource: ds,
+          gridPos: { h: 8, w: 6, x: 12, y: 22 },
+          targets: [
+            prom('smartctl_device_attribute{%(sel)s, instance=~"$instance", attribute_name="Offline_Uncorrectable", attribute_value_type="raw"}' % { sel: sel }, '{{instance}} - {{device}}', false, 'Offline sectors'),
+          ],
+          fieldConfig: {
+            defaults: statDefaults([step('text'), step('red', 1)]),
+            overrides: [],
+          },
+          options: {
+            colorMode: 'background',
+            graphMode: 'none',
+            reduceOptions: { calcs: ['lastNotNull'], fields: '', values: false },
+            textMode: 'auto',
+            wideLayout: true,
+          },
+        },
+
+        // Current pending sectors
+        {
+          id: 11,
+          type: 'stat',
+          title: 'Current pending sectors',
+          description: 'Sectors waiting to be reallocated. Any value > 0 is concerning and may indicate imminent disk failure',
+          datasource: ds,
+          gridPos: { h: 8, w: 6, x: 18, y: 22 },
+          targets: [
+            prom('smartctl_device_attribute{%(sel)s, instance=~"$instance", attribute_name="Current_Pending_Sector", attribute_value_type="raw"}' % { sel: sel }, '{{instance}} - {{device}}', false, 'Pending sectors'),
+          ],
+          fieldConfig: {
+            defaults: statDefaults([step('text'), step('red', 1)]),
+            overrides: [],
+          },
+          options: {
+            colorMode: 'background',
+            graphMode: 'none',
+            reduceOptions: { calcs: ['lastNotNull'], fields: '', values: false },
+            textMode: 'auto',
+            wideLayout: true,
+          },
+        },
+
+        // Reallocated sectors
+        {
+          id: 10,
+          type: 'timeseries',
+          title: 'Reallocated sectors',
+          description: 'Count of reallocated sectors. Any value > 0 indicates disk is wearing out. Steep increase indicates potential imminent failure.',
+          datasource: ds,
+          gridPos: { h: 8, w: 12, x: 0, y: 30 },
+          targets: [
+            prom('sum by (instance, device)(smartctl_device_attribute{%(sel)s, instance=~"$instance", attribute_name="Reallocated_Sector_Ct", attribute_value_type="raw"})' % { sel: sel }, '{{instance}} - {{device}}', false, 'Reallocated sectors'),
+          ],
+          fieldConfig: {
+            defaults: tsDefaults('short', [step('green'), step('yellow', 5), step('red', 50)]),
+            overrides: [],
+          },
+          options: tsOptions,
+        },
+
+        // Error log count
+        {
+          id: 13,
+          type: 'timeseries',
+          title: 'Error log count',
+          description: 'Count of errors logged by the disk controller',
+          datasource: ds,
+          gridPos: { h: 8, w: 12, x: 12, y: 30 },
+          targets: [
+            prom('sum by (instance, device)(smartctl_device_error_log_count{%(sel)s, instance=~"$instance"})' % { sel: sel }, '{{instance}} - {{device}}', false, 'Errors'),
+          ],
+          fieldConfig: {
+            defaults: tsDefaults('short', [step('green'), step('yellow', 1), step('red', 10)]),
+            overrides: [],
+          },
+          options: tsOptions,
+        },
+
+        // ----------------------------------------------------------------
+        // NVMe row
+        // ----------------------------------------------------------------
+        {
+          id: 102,
+          type: 'row',
+          title: 'NVMe',
+          gridPos: { h: 1, w: 24, x: 0, y: 38 },
+          collapsed: false,
+          panels: [],
+        },
+
+        // NVMe percentage used
+        {
+          id: 15,
+          type: 'gauge',
+          title: 'NVMe percentage used',
+          description: 'Percentage of NVMe device life used. Values approaching 100% indicate end of life',
+          datasource: ds,
+          gridPos: { h: 8, w: 6, x: 0, y: 39 },
+          targets: [
+            prom('smartctl_device_percentage_used{%(sel)s, instance=~"$instance"}' % { sel: sel }, '{{instance}} - {{device}}', true, 'NVMe life'),
+          ],
+          fieldConfig: {
+            defaults: {
+              unit: 'percent',
+              min: 0,
+              max: 100,
+              color: { mode: 'thresholds' },
+              thresholds: { mode: 'absolute', steps: [step('blue'), step('yellow', 80), step('red', 95)] },
+            },
+            overrides: [],
+          },
+          options: {
+            orientation: 'auto',
+            reduceOptions: { calcs: ['lastNotNull'], fields: '', values: false },
+            showThresholdLabels: false,
+            showThresholdMarkers: true,
+            textMode: 'auto',
+          },
+        },
+
+        // NVMe media errors
+        {
+          id: 14,
+          type: 'timeseries',
+          title: 'NVMe media errors',
+          description: 'Media errors for NVMe devices. Any value > 0 indicates potential issues',
+          datasource: ds,
+          gridPos: { h: 8, w: 12, x: 6, y: 39 },
+          targets: [
+            prom('sum by (instance, device)(smartctl_device_media_errors{%(sel)s, instance=~"$instance"})' % { sel: sel }, '{{instance}} - {{device}}', false, 'NVme errors'),
+          ],
+          fieldConfig: {
+            defaults: tsDefaults('short', [step('blue'), step('red', 1)]),
+            overrides: [],
+          },
+          options: tsOptions,
+        },
+      ],
+    },
+  },
+}

--- a/mixin/jsonnetfile.json
+++ b/mixin/jsonnetfile.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "dependencies": [],
+  "legacyImports": false,
+}

--- a/mixin/mixin.libsonnet
+++ b/mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'config.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'dashboards/smartctl.libsonnet')

--- a/mixin/output/smartctl-overview.json
+++ b/mixin/output/smartctl-overview.json
@@ -1,0 +1,1235 @@
+{
+   "panels": [
+      {
+         "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 31,
+         "options": {
+            "content": "<div style=\"background: linear-gradient(135deg, #0d1117 0%, #1a1f2e 60%, #0f172a 100%); padding: 18px 28px; display: flex; align-items: center; gap: 22px; border-radius: 6px; border-left: 4px solid #3b82f6;\">\n  <div>\n    <div style=\"color: #e2e8f0; margin: 0; font-size: 26px; font-weight: 700;\">S.M.A.R.T. Disk Health Monitoring</div>\n    <div style=\"color: #64748b; margin: 5px 0 0; font-size: 13px;\">Self-Monitoring, Analysis and Reporting Technology &mdash; real-time disk diagnostics &amp; predictive failure analysis</div>\n  </div>\n</div>",
+            "mode": "html"
+         },
+         "transparent": true,
+         "type": "text"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 4
+         },
+         "id": 100,
+         "panels": [ ],
+         "title": "Overview",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Exit status from smartctl command for all devices selected. Indicates if metrics are collected properly.",
+         "fieldConfig": {
+            "defaults": {
+               "mappings": [
+                  {
+                     "options": {
+                        "0": {
+                           "index": 0,
+                           "text": "Running"
+                        }
+                     },
+                     "type": "value"
+                  },
+                  {
+                     "options": {
+                        "from": 1,
+                        "result": {
+                           "index": 1,
+                           "text": "smartctl errors"
+                        },
+                        "to": null
+                     },
+                     "type": "range"
+                  }
+               ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue"
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 0,
+            "y": 5
+         },
+         "id": 19,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "max"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "value",
+            "wideLayout": true
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "max(smartctl_device_smartctl_exit_status{job=\"smartctl\", instance=~\"$instance\"} > 0 or vector(0))",
+               "instant": false,
+               "legendFormat": "__auto",
+               "range": true,
+               "refId": "Probe status"
+            }
+         ],
+         "title": "SMART probe",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Number of seconds each disk has been powered on",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+               },
+               "decimals": 1,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "text"
+                     }
+                  ]
+               },
+               "unit": "s"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 4,
+            "y": 5
+         },
+         "id": 7,
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "max by (instance, device)(smartctl_device_power_on_seconds{job=\"smartctl\", instance=~\"$instance\"})",
+               "instant": true,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": false,
+               "refId": "On-time"
+            }
+         ],
+         "title": "Disk power-on time",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Disk temperatures over time for each device",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisPlacement": "auto",
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "lineInterpolation": "smooth",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "dashed"
+                  }
+               },
+               "max": 70,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue"
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 50
+                     },
+                     {
+                        "color": "red",
+                        "value": 60
+                     }
+                  ]
+               },
+               "unit": "celsius"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 5
+         },
+         "id": 6,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "lastNotNull",
+                  "median"
+               ],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "sum by (instance, device)(smartctl_device_temperature{job=\"smartctl\", instance=~\"$instance\", temperature_type=\"current\"}) and on(instance, device) smartctl_device{model_name!=\"IET VIRTUAL-DISK\"}",
+               "instant": false,
+               "legendFormat": "{{instance}}/{{device}}",
+               "range": true,
+               "refId": "Temperature"
+            }
+         ],
+         "title": "Disk temperature",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Number of disks with failing SMART status. Indicates disk death.",
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "transparent"
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 8
+         },
+         "id": 20,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "value_and_name",
+            "wideLayout": true
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "count by (instance)(smartctl_device{job=\"smartctl\", instance=~\"$instance\"}) - count by (instance)(smartctl_device_smart_status{job=\"smartctl\", instance=~\"$instance\"} == 1)",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false,
+               "refId": "Failing disks"
+            }
+         ],
+         "title": "Failed disks count",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green"
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 12
+         },
+         "id": 30,
+         "options": {
+            "cellHeight": "sm",
+            "enablePagination": true,
+            "showHeader": true
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "smartctl_device{job=\"smartctl\", instance=~\"$instance\", model_name!=\"IET VIRTUAL-DISK\"}",
+               "format": "table",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false,
+               "refId": "Devices"
+            }
+         ],
+         "title": "Devices in scope",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value": true,
+                     "__name__": true,
+                     "ata_additional_product_id": true,
+                     "ata_version": true,
+                     "container": true,
+                     "firmware_version": true,
+                     "interface": true,
+                     "job": true,
+                     "k8s_cluster_name": true,
+                     "model_family": true,
+                     "namespace": true,
+                     "pod": true,
+                     "protocol": true,
+                     "sata_version": true
+                  },
+                  "indexByName": {
+                     "Time": 0,
+                     "Value": 15,
+                     "__name__": 1,
+                     "ata_additional_product_id": 2,
+                     "ata_version": 3,
+                     "device": 5,
+                     "firmware_version": 6,
+                     "form_factor": 7,
+                     "instance": 4,
+                     "interface": 8,
+                     "job": 9,
+                     "model_family": 10,
+                     "model_name": 11,
+                     "protocol": 12,
+                     "sata_version": 13,
+                     "serial_number": 14
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Detailed prefailured checks below thresholds. Indicates the disks are wearing out and need to be replaced with no immediate failure.",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+               },
+               "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "transparent"
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "attribute_name"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "pill"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+         },
+         "id": 25,
+         "options": {
+            "cellHeight": "sm",
+            "enablePagination": true,
+            "frameIndex": 1,
+            "showHeader": true,
+            "sortBy": [
+               {
+                  "desc": false,
+                  "displayName": "attribute_id"
+               }
+            ]
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "max by(instance, device, attribute_name)(smartctl_device_attribute{job=\"smartctl\", instance=~\"$instance\", attribute_flags_short=~\"P.....\", attribute_value_type=\"value\"}) <= max by(instance, device, attribute_name)(smartctl_device_attribute{job=\"smartctl\", instance=~\"$instance\", attribute_flags_short=~\"P.....\", attribute_value_type=\"thresh\"})",
+               "format": "table",
+               "instant": true,
+               "legendFormat": "__auto",
+               "range": false,
+               "refId": "Prefailure checks"
+            }
+         ],
+         "title": "Prefailure checks below thresholds",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value": true
+                  },
+                  "indexByName": {
+                     "Time": 0,
+                     "Value": 4,
+                     "attribute_name": 3,
+                     "device": 2,
+                     "instance": 1
+                  },
+                  "renameByName": {
+                     "attribute_name": ""
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 21
+         },
+         "id": 101,
+         "panels": [ ],
+         "title": "HDD / SSD",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Disks with any error logs, unrecoverable/reallocated/pending sectors on HDD. Could indicate imminent failure or data corruption.",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "transparent"
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               }
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 22
+         },
+         "id": 26,
+         "options": {
+            "cellHeight": "sm",
+            "enablePagination": true,
+            "showHeader": true
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "sum by (instance, device)(max_over_time(smartctl_device_attribute{job=\"smartctl\", instance=~\"$instance\", attribute_name=~\"Offline_Uncorrectable|Current_Pending_Sector|Reallocated_Sector_Ct\", attribute_value_type=\"raw\"}[$__range])) > 0",
+               "format": "table",
+               "instant": true,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": false,
+               "refId": "Failing HDD"
+            }
+         ],
+         "title": "Failing HDDs",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value": true
+                  },
+                  "renameByName": {
+                     "device": "Device",
+                     "instance": "Instance"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Remaining life measured for SSDs",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "red"
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 10
+                     },
+                     {
+                        "color": "blue",
+                        "value": 30
+                     }
+                  ]
+               },
+               "unit": "percent"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 22
+         },
+         "id": 29,
+         "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "textMode": "auto"
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "smartctl_device_attribute{job=\"smartctl\", instance=~\"$instance\", attribute_name=\"Media_Wearout_Indicator\", attribute_value_type=\"value\"}",
+               "instant": true,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": false,
+               "refId": "SSD wearout"
+            }
+         ],
+         "title": "SSD wearout indicator",
+         "type": "gauge"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Uncorrectable sectors. Any value > 0 indicates data loss or corruption risk",
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "text"
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 22
+         },
+         "id": 12,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "smartctl_device_attribute{job=\"smartctl\", instance=~\"$instance\", attribute_name=\"Offline_Uncorrectable\", attribute_value_type=\"raw\"}",
+               "instant": false,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": true,
+               "refId": "Offline sectors"
+            }
+         ],
+         "title": "Offline uncorrectable sectors",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Sectors waiting to be reallocated. Any value > 0 is concerning and may indicate imminent disk failure",
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "text"
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 22
+         },
+         "id": 11,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "smartctl_device_attribute{job=\"smartctl\", instance=~\"$instance\", attribute_name=\"Current_Pending_Sector\", attribute_value_type=\"raw\"}",
+               "instant": false,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": true,
+               "refId": "Pending sectors"
+            }
+         ],
+         "title": "Current pending sectors",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Count of reallocated sectors. Any value > 0 indicates disk is wearing out. Steep increase indicates potential imminent failure.",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisPlacement": "auto",
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "lineInterpolation": "smooth",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "max": null,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green"
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 5
+                     },
+                     {
+                        "color": "red",
+                        "value": 50
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 30
+         },
+         "id": 10,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "lastNotNull",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "sum by (instance, device)(smartctl_device_attribute{job=\"smartctl\", instance=~\"$instance\", attribute_name=\"Reallocated_Sector_Ct\", attribute_value_type=\"raw\"})",
+               "instant": false,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": true,
+               "refId": "Reallocated sectors"
+            }
+         ],
+         "title": "Reallocated sectors",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Count of errors logged by the disk controller",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisPlacement": "auto",
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "lineInterpolation": "smooth",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "max": null,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green"
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 1
+                     },
+                     {
+                        "color": "red",
+                        "value": 10
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 30
+         },
+         "id": 13,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "lastNotNull",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "sum by (instance, device)(smartctl_device_error_log_count{job=\"smartctl\", instance=~\"$instance\"})",
+               "instant": false,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": true,
+               "refId": "Errors"
+            }
+         ],
+         "title": "Error log count",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 38
+         },
+         "id": 102,
+         "panels": [ ],
+         "title": "NVMe",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Percentage of NVMe device life used. Values approaching 100% indicate end of life",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue"
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 80
+                     },
+                     {
+                        "color": "red",
+                        "value": 95
+                     }
+                  ]
+               },
+               "unit": "percent"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 39
+         },
+         "id": 15,
+         "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "textMode": "auto"
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "smartctl_device_percentage_used{job=\"smartctl\", instance=~\"$instance\"}",
+               "instant": true,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": false,
+               "refId": "NVMe life"
+            }
+         ],
+         "title": "NVMe percentage used",
+         "type": "gauge"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+         },
+         "description": "Media errors for NVMe devices. Any value > 0 indicates potential issues",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisPlacement": "auto",
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "lineInterpolation": "smooth",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "max": null,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue"
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 6,
+            "y": 39
+         },
+         "id": 14,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "lastNotNull",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROMETHEUS}"
+               },
+               "editorMode": "code",
+               "exemplar": false,
+               "expr": "sum by (instance, device)(smartctl_device_media_errors{job=\"smartctl\", instance=~\"$instance\"})",
+               "instant": false,
+               "legendFormat": "{{instance}} - {{device}}",
+               "range": true,
+               "refId": "NVme errors"
+            }
+         ],
+         "title": "NVMe media errors",
+         "type": "timeseries"
+      }
+   ],
+   "refresh": "",
+   "schemaVersion": 39,
+   "tags": [
+      "smartctl-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "Prometheus",
+               "value": "Prometheus"
+            },
+            "hide": 0,
+            "label": "Prometheus datasource",
+            "name": "DS_PROMETHEUS",
+            "query": "prometheus",
+            "type": "datasource"
+         },
+         {
+            "current": {
+               "selected": false,
+               "text": "All",
+               "value": "$__all"
+            },
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${DS_PROMETHEUS}"
+            },
+            "includeAll": true,
+            "label": "Instance",
+            "multi": true,
+            "name": "instance",
+            "options": [ ],
+            "query": "label_values(smartctl_device_smart_status{job=\"smartctl\"}, instance)",
+            "refresh": 1,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-12h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "SMART Disk Health Monitoring",
+   "uid": "smartctl-overview",
+   "version": 1
+}

--- a/mixin/output/smartctl_alerts.yaml
+++ b/mixin/output/smartctl_alerts.yaml
@@ -1,0 +1,96 @@
+"groups":
+- "interval": "10m"
+  "name": "smartctl"
+  "rules":
+  - "alert": "SmartDeviceTemperatureWarning"
+    "annotations":
+      "description": "Device temperature warning on {{ $labels.instance }} drive {{ $labels.device }} over 60°C. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART device temperature warning (instance {{ $labels.instance }})"
+    "expr": |
+      (
+        avg_over_time(smartctl_device_temperature{job="smartctl", temperature_type="current"}[5m])
+          unless on (instance, device) smartctl_device_temperature{job="smartctl", temperature_type="drive_trip"}
+      ) > 60
+    "for": "10m"
+    "labels":
+      "severity": "warning"
+  - "alert": "SmartDeviceTemperatureCritical"
+    "annotations":
+      "description": "Device temperature critical on {{ $labels.instance }} drive {{ $labels.device }} over 70°C. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART device temperature critical (instance {{ $labels.instance }})"
+    "expr": |
+      (
+        max_over_time(smartctl_device_temperature{job="smartctl", temperature_type="current"}[5m])
+          unless on (instance, device) smartctl_device_temperature{job="smartctl", temperature_type="drive_trip"}
+      ) > 70
+    "for": "10m"
+    "labels":
+      "severity": "critical"
+  - "alert": "SmartDeviceTemperatureOverTripValue"
+    "annotations":
+      "description": "Device temperature over trip value on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART device temperature over trip value (instance {{ $labels.instance }})"
+    "expr": |
+      max_over_time(smartctl_device_temperature{job="smartctl", temperature_type="current"}[10m])
+        > on (device, instance) smartctl_device_temperature{job="smartctl", temperature_type="drive_trip"}
+    "for": "10m"
+    "labels":
+      "severity": "critical"
+  - "alert": "SmartDeviceTemperatureNearingTripValue"
+    "annotations":
+      "description": "Device temperature nearing trip value on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART device temperature nearing trip value (instance {{ $labels.instance }})"
+    "expr": |
+      max_over_time(smartctl_device_temperature{job="smartctl", temperature_type="current"}[10m])
+        > on (device, instance) (smartctl_device_temperature{job="smartctl", temperature_type="drive_trip"} * 0.800000)
+    "for": "10m"
+    "labels":
+      "severity": "warning"
+  - "alert": "SmartStatus"
+    "annotations":
+      "description": "Device has a SMART status failure on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART status (instance {{ $labels.instance }})"
+    "expr": "smartctl_device_smart_status{job=\"smartctl\"} != 1"
+    "for": "10m"
+    "labels":
+      "severity": "critical"
+  - "alert": "SmartCriticalWarning"
+    "annotations":
+      "description": "Disk controller has critical warning on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART critical warning (instance {{ $labels.instance }})"
+    "expr": "smartctl_device_critical_warning{job=\"smartctl\"} > 0"
+    "for": "10m"
+    "labels":
+      "severity": "critical"
+  - "alert": "SmartMediaErrors"
+    "annotations":
+      "description": "Disk controller detected media errors on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART media errors (instance {{ $labels.instance }})"
+    "expr": "smartctl_device_media_errors{job=\"smartctl\"} > 0"
+    "for": "10m"
+    "labels":
+      "severity": "critical"
+  - "alert": "SmartWearoutIndicator"
+    "annotations":
+      "description": "Device is wearing out on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART Wearout Indicator (instance {{ $labels.instance }})"
+    "expr": "smartctl_device_available_spare{job=\"smartctl\"} < smartctl_device_available_spare_threshold{job=\"smartctl\"}"
+    "for": "10m"
+    "labels":
+      "severity": "critical"
+  - "alert": "SmartDeviceSSDWearingOut"
+    "annotations":
+      "description": "Less than 10% lifetime remaining on SSD on {{ $labels.instance }} drive {{ $labels.device }}. VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SSD is wearing out (instance {{ $labels.instance }})"
+    "expr": "smartctl_device_attribute{job=\"smartctl\", attribute_name=\"Media_Wearout_Indicator\", attribute_value_type=\"value\"} < 10"
+    "for": "10m"
+    "labels":
+      "severity": "warning"
+  - "alert": "SmartErrorLogs"
+    "annotations":
+      "description": "Device logged warnings on {{ $labels.instance }} (drive {{ $labels.device }}). VALUE = {{ $value }}. LABELS = {{ $labels }}"
+      "summary": "SMART Warning Logs on {{ $labels.instance }}"
+    "expr": "smartctl_device_error_log_count{job=\"smartctl\"} > 0"
+    "for": "10m"
+    "labels":
+      "severity": "critical"


### PR DESCRIPTION
Hello,

As I suspected, one of my disk was failing and so I took time to build a dashboard and a set of alerts to proactively monitor this. Instead of having a separate unknown repo somewhere, I hereby submit this mixin to share and develop with the community.

The dashboard and alerts are pre-compiled in the output folder.

BTW, it's my first mixin. I tried to follow some examples from other mixins but I am gueninely not sure what are the best practices there. It works but happy to tweak anything to comply with a different way of doing that.

## Dashboard
<img width="2557" height="1323" alt="image" src="https://github.com/user-attachments/assets/7f9a55d0-ca17-4f3d-8a67-f775b5e4fb08" />

Variables:
- Prometheus datasource
- Instance (multi-values)

3 rows:
- General overview:
  - state of the probes (smartctl exit status)
  - number of disk failing
  - list of disks (id, instance, serial numbers, model, etc)
  - temperature graph
  - list of prefailures checks met
- HDD / SDD
  - Count of failing disks (all signals aggregated)
  - SSD wearout
  - Offline sectors
  - Pending sectors
  - Reallocated sectors (graph as steep increase is a clearer signal than a steady low number)
  - Error log count (graph, same reason)
- NVMe
  - Lifetime
  - Media errors

## Alerts
- Temperature warning (60°C)
- Temperature critical (70°C)
- Temperature near trip value
- Temperature over trip value
- SMART status (smartctl exit status)
- Media errors
- Critical warning
- Wearout indicator
- SSD wearout indicator
- SMART Error logs increase