### PR TITLE
docs: drop the removed smartctl_device_status metric from EXAMPLE.md

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -504,13 +504,6 @@ smartctl_device_smartctl_exit_status{device="/dev/sda"} 0
 smartctl_device_smartctl_exit_status{device="/dev/sdb"} 0
 smartctl_device_smartctl_exit_status{device="/dev/sdc"} 0
 smartctl_device_smartctl_exit_status{device="/dev/sdd"} 0
-# HELP smartctl_device_status Device status
-# TYPE smartctl_device_status gauge
-smartctl_device_status{device="/dev/nvme0"} 0
-smartctl_device_status{device="/dev/sda"} 1
-smartctl_device_status{device="/dev/sdb"} 1
-smartctl_device_status{device="/dev/sdc"} 1
-smartctl_device_status{device="/dev/sdd"} 1
 # HELP smartctl_device_temperature Device temperature celsius
 # TYPE smartctl_device_temperature gauge
 smartctl_device_temperature{device="/dev/nvme0",temperature_type="current"} 37


### PR DESCRIPTION
Closes #351.

`smartctl_device_status` was removed in #137 (8331d7f, Aug 2023) as a duplicate of `smartctl_device_smart_status`, but that PR only touched `metrics.go` and `smartctl.go` — `EXAMPLE.md` kept showing it in the sample `/metrics` output, so it still reads as a metric you can scrape.

Checked that nothing else is stale: comparing every `# HELP` name in `EXAMPLE.md` against the metric names in the Go sources, `smartctl_device_status` is the only one with no collector behind it. `smartctl_device_smart_status` is already present in the same example a few lines above (and is what the removal commit kept), so the block is just deleted rather than renamed.

The only remaining mention is the `CHANGELOG.md` entry recording the removal, which is correct as-is.

Docs only, no code change.