### PR TITLE
Add Seagate FARM log metrics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Flags:
       --smartctl.device-include=""
                                Regexp of devices to include in automatic scanning. (mutually exclusive to
                                device-exclude)
+      --smartctl.farm-log      Collect Seagate FARM log metrics (requires smartmontools 7.4+)
       --web.telemetry-path="/metrics"  
                                Path under which to expose metrics
       --web.systemd-socket     Use systemd socket activation listeners instead of port listeners (Linux only).
@@ -53,6 +54,16 @@ Flags:
       --log.format=logfmt      Output format of log messages. One of: [logfmt, json]
       --version                Show application version.
 ```
+
+    ### Seagate FARM metrics
+
+    Seagate Field Accessible Reliability Metrics (FARM) collection is disabled by
+    default. Enable it with `--smartctl.farm-log`. This adds `--log=farm` to the
+    smartctl invocation and exports workload, error, environment, and reliability
+    metrics under the `smartctl_device_farm_` prefix.
+
+    FARM collection requires smartmontools 7.4 or newer. Devices without FARM
+    support continue to export their regular SMART metrics.
 
 ## TLS and basic authentication
 

--- a/farm.go
+++ b/farm.go
@@ -1,0 +1,355 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tidwall/gjson"
+)
+
+// mineFarmLog collects Seagate FARM log metrics if present in the JSON.
+func (smart *SMARTctl) mineFarmLog() {
+	farmLog := smart.json.Get("seagate_farm_log")
+	if !farmLog.Exists() {
+		return
+	}
+	smart.logger.Debug("Collecting Seagate FARM log metrics", "device", smart.device.device)
+	smart.mineFarmWorkload(farmLog)
+	smart.mineFarmErrors(farmLog)
+	smart.mineFarmEnvironment(farmLog)
+	smart.mineFarmReliability(farmLog)
+}
+
+func (smart *SMARTctl) mineFarmWorkload(farmLog gjson.Result) {
+	workload := farmLog.Get("page_2_workload_statistics")
+	if !workload.Exists() {
+		return
+	}
+
+	if v := workload.Get("total_read_commands"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmWorkloadReadCommands,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := workload.Get("total_write_commands"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmWorkloadWriteCommands,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := workload.Get("logical_sectors_read"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmWorkloadLogicalSectorsRead,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := workload.Get("logical_sectors_written"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmWorkloadLogicalSectorsWritten,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+}
+
+func (smart *SMARTctl) mineFarmErrors(farmLog gjson.Result) {
+	errors := farmLog.Get("page_3_error_statistics")
+	if !errors.Exists() {
+		return
+	}
+
+	if v := errors.Get("number_of_unrecoverable_read_errors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorUnrecoverableRead,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("number_of_unrecoverable_write_errors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorUnrecoverableWrite,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("number_of_reallocated_sectors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorReallocatedSectors,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("number_of_reallocated_candidate_sectors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorReallocatedCandidates,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("total_crc_errors"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorCRCErrors,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := errors.Get("command_time_out_count_total"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmErrorCommandTimeouts,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+
+	// Per-head unrecoverable error metrics
+	smart.mineFarmErrorsByHead(errors)
+}
+
+func (smart *SMARTctl) mineFarmErrorsByHead(errors gjson.Result) {
+	errors.ForEach(func(key, value gjson.Result) bool {
+		keyStr := key.String()
+		if !strings.HasPrefix(keyStr, "cum_lifetime_unrecoverable_by_head_") {
+			return true
+		}
+		head := strings.TrimPrefix(keyStr, "cum_lifetime_unrecoverable_by_head_")
+		if !value.IsObject() {
+			return true
+		}
+		if v := value.Get("cum_lifetime_unrecoverable_read_repeating"); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmErrorUnrecoverableByHead,
+				prometheus.CounterValue,
+				v.Float(),
+				smart.device.device,
+				head,
+				"read_repeating",
+			)
+		}
+		if v := value.Get("cum_lifetime_unrecoverable_read_unique"); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmErrorUnrecoverableByHead,
+				prometheus.CounterValue,
+				v.Float(),
+				smart.device.device,
+				head,
+				"read_unique",
+			)
+		}
+		return true
+	})
+}
+
+func (smart *SMARTctl) mineFarmEnvironment(farmLog gjson.Result) {
+	env := farmLog.Get("page_4_environment_statistics")
+	if !env.Exists() {
+		return
+	}
+
+	tempFields := map[string]string{
+		"curent_temp":        "current",
+		"highest_temp":       "highest",
+		"lowest_temp":        "lowest",
+		"average_temp":       "average",
+		"average_long_temp":  "average_long",
+		"highest_short_temp": "highest_short",
+		"lowest_short_temp":  "lowest_short",
+		"highest_long_temp":  "highest_long",
+		"lowest_long_temp":   "lowest_long",
+	}
+	for field, label := range tempFields {
+		if v := env.Get(field); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmEnvironmentTemperature,
+				prometheus.GaugeValue,
+				v.Float(),
+				smart.device.device,
+				label,
+			)
+		}
+	}
+
+	if v := env.Get("humidity"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmEnvironmentHumidity,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+
+	if v := env.Get("current_motor_power"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmEnvironmentMotorPower,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+
+	voltageFields12V := map[string]string{
+		"current_12v_in_mv": "current",
+		"minimum_12v_in_mv": "minimum",
+		"maximum_12v_in_mv": "maximum",
+	}
+	for field, label := range voltageFields12V {
+		if v := env.Get(field); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmEnvironment12V,
+				prometheus.GaugeValue,
+				v.Float(),
+				smart.device.device,
+				label,
+			)
+		}
+	}
+
+	voltageFields5V := map[string]string{
+		"current_5v_in_mv": "current",
+		"minimum_5v_in_mv": "minimum",
+		"maximum_5v_in_mv": "maximum",
+	}
+	for field, label := range voltageFields5V {
+		if v := env.Get(field); v.Exists() {
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmEnvironment5V,
+				prometheus.GaugeValue,
+				v.Float(),
+				smart.device.device,
+				label,
+			)
+		}
+	}
+}
+
+func (smart *SMARTctl) mineFarmReliability(farmLog gjson.Result) {
+	rel := farmLog.Get("page_5_reliability_statistics")
+	if !rel.Exists() {
+		return
+	}
+
+	if v := rel.Get("attr_error_rate_raw"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmReliabilityErrorRate,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := rel.Get("attr_seek_error_rate_raw"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmReliabilitySeekErrorRate,
+			prometheus.GaugeValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := rel.Get("high_priority_unload_events"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmReliabilityHighPriorityUnloads,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+	if v := rel.Get("helium_presure_trip"); v.Exists() {
+		smart.ch <- prometheus.MustNewConstMetric(
+			metricFarmReliabilityHeliumPressureTrip,
+			prometheus.CounterValue,
+			v.Float(),
+			smart.device.device,
+		)
+	}
+
+	// Per-head reliability metrics
+	smart.mineFarmReliabilityByHead(rel)
+}
+
+func (smart *SMARTctl) mineFarmReliabilityByHead(rel gjson.Result) {
+	// Reallocated sectors by head
+	rel.ForEach(func(key, value gjson.Result) bool {
+		keyStr := key.String()
+
+		if strings.HasPrefix(keyStr, "number_of_reallocated_sectors_by_head_") {
+			head := strings.TrimPrefix(keyStr, "number_of_reallocated_sectors_by_head_")
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmReliabilityReallocatedByHead,
+				prometheus.GaugeValue,
+				value.Float(),
+				smart.device.device,
+				head,
+			)
+		} else if strings.HasPrefix(keyStr, "number_of_reallocation_candidate_sectors_by_head_") {
+			head := strings.TrimPrefix(keyStr, "number_of_reallocation_candidate_sectors_by_head_")
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmReliabilityCandidatesByHead,
+				prometheus.GaugeValue,
+				value.Float(),
+				smart.device.device,
+				head,
+			)
+		} else if strings.HasPrefix(keyStr, "mr_head_resistance_from_head_") {
+			head := strings.TrimPrefix(keyStr, "mr_head_resistance_from_head_")
+			smart.ch <- prometheus.MustNewConstMetric(
+				metricFarmReliabilityMRHeadResistanceByHead,
+				prometheus.GaugeValue,
+				value.Float(),
+				smart.device.device,
+				head,
+			)
+		}
+
+		return true
+	})
+
+	// Skip write detect by head — multiple types per head
+	headCount := smart.json.Get("seagate_farm_log.page_1_drive_information.number_of_heads").Int()
+	for i := int64(0); i < headCount; i++ {
+		head := fmt.Sprintf("%d", i)
+		skipTypes := map[string]string{
+			fmt.Sprintf("dvga_skip_write_detect_by_head_%d", i):               "dvga",
+			fmt.Sprintf("rvga_skip_write_detect_by_head_%d", i):               "rvga",
+			fmt.Sprintf("fvga_skip_write_detect_by_head_%d", i):               "fvga",
+			fmt.Sprintf("skip_write_detect_threshold_exceeded_by_head_%d", i): "threshold_exceeded",
+		}
+		for field, detectType := range skipTypes {
+			if v := rel.Get(field); v.Exists() {
+				smart.ch <- prometheus.MustNewConstMetric(
+					metricFarmReliabilitySkipWriteByHead,
+					prometheus.GaugeValue,
+					v.Float(),
+					smart.device.device,
+					head,
+					detectType,
+				)
+			}
+		}
+	}
+}

--- a/farm_test.go
+++ b/farm_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tidwall/gjson"
+)
+
+func TestMineFarmLog(t *testing.T) {
+	jsonFile, err := os.ReadFile("testdata/sat-Seagate_Exos_X18-ST12000NM000J-farm.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	json := gjson.Parse(string(jsonFile))
+	ch := make(chan prometheus.Metric, 1000)
+
+	smart := NewSMARTctl(slog.Default(), json, ch)
+	smart.mineFarmLog()
+	close(ch)
+
+	metrics := make(map[string][]prometheus.Metric)
+	for m := range ch {
+		metrics[m.Desc().String()] = append(metrics[m.Desc().String()], m)
+	}
+
+	// Verify workload metrics
+	assertMetricCount(t, metrics, metricFarmWorkloadReadCommands, 1)
+	assertMetricCount(t, metrics, metricFarmWorkloadWriteCommands, 1)
+	assertMetricCount(t, metrics, metricFarmWorkloadLogicalSectorsRead, 1)
+	assertMetricCount(t, metrics, metricFarmWorkloadLogicalSectorsWritten, 1)
+
+	// Verify error metrics
+	assertMetricCount(t, metrics, metricFarmErrorUnrecoverableRead, 1)
+	assertMetricCount(t, metrics, metricFarmErrorUnrecoverableWrite, 1)
+	assertMetricCount(t, metrics, metricFarmErrorReallocatedSectors, 1)
+	assertMetricCount(t, metrics, metricFarmErrorReallocatedCandidates, 1)
+	assertMetricCount(t, metrics, metricFarmErrorCRCErrors, 1)
+	assertMetricCount(t, metrics, metricFarmErrorCommandTimeouts, 1)
+
+	// Verify per-head error metrics: 16 heads * 2 types = 32
+	assertMetricCount(t, metrics, metricFarmErrorUnrecoverableByHead, 32)
+
+	// Verify environment metrics
+	assertMetricCount(t, metrics, metricFarmEnvironmentTemperature, 9)
+	assertMetricCount(t, metrics, metricFarmEnvironmentHumidity, 1)
+	assertMetricCount(t, metrics, metricFarmEnvironmentMotorPower, 1)
+	// 12V and 5V all have value 0 but still exist in JSON
+	assertMetricCount(t, metrics, metricFarmEnvironment12V, 3)
+	assertMetricCount(t, metrics, metricFarmEnvironment5V, 3)
+
+	// Verify reliability metrics
+	assertMetricCount(t, metrics, metricFarmReliabilityErrorRate, 1)
+	assertMetricCount(t, metrics, metricFarmReliabilitySeekErrorRate, 1)
+	assertMetricCount(t, metrics, metricFarmReliabilityHighPriorityUnloads, 1)
+	assertMetricCount(t, metrics, metricFarmReliabilityHeliumPressureTrip, 1)
+
+	// Per-head reliability: 16 heads each
+	assertMetricCount(t, metrics, metricFarmReliabilityReallocatedByHead, 16)
+	assertMetricCount(t, metrics, metricFarmReliabilityCandidatesByHead, 16)
+	assertMetricCount(t, metrics, metricFarmReliabilityMRHeadResistanceByHead, 16)
+	// Skip write: 16 heads * 4 types = 64
+	assertMetricCount(t, metrics, metricFarmReliabilitySkipWriteByHead, 64)
+}
+
+func TestMineFarmLogAbsentKey(t *testing.T) {
+	// Test that no FARM metrics are emitted when seagate_farm_log is missing
+	json := gjson.Parse(`{"device": {"name": "/dev/sda", "type": "sat", "protocol": "ATA"}, "model_name": "WDC WD10EZEX"}`)
+	ch := make(chan prometheus.Metric, 100)
+
+	smart := NewSMARTctl(slog.Default(), json, ch)
+	smart.mineFarmLog()
+	close(ch)
+
+	count := 0
+	for range ch {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 metrics for non-Seagate drive, got %d", count)
+	}
+}
+
+func assertMetricCount(t *testing.T, metrics map[string][]prometheus.Metric, desc *prometheus.Desc, expected int) {
+	t.Helper()
+	actual := len(metrics[desc.String()])
+	if actual != expected {
+		t.Errorf("metric %s: expected %d, got %d", desc, expected, actual)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -126,6 +126,9 @@ var (
 	smartctlPowerModeCheck = kingpin.Flag("smartctl.powermode-check",
 		"Whether or not to check powermode before fetching data",
 	).Default("standby").String()
+	smartctlFarmLog = kingpin.Flag("smartctl.farm-log",
+		"Collect Seagate FARM log metrics (requires smartmontools 7.4+)",
+	).Default("false").Bool()
 )
 
 // scanDevices uses smartctl to gather the list of available devices.

--- a/metrics.go
+++ b/metrics.go
@@ -354,4 +354,150 @@ var (
 		},
 		nil,
 	)
+
+	// Seagate FARM log metrics
+	metricFarmWorkloadReadCommands = prometheus.NewDesc(
+		"smartctl_device_farm_workload_read_commands_total",
+		"Seagate FARM total read commands",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmWorkloadWriteCommands = prometheus.NewDesc(
+		"smartctl_device_farm_workload_write_commands_total",
+		"Seagate FARM total write commands",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmWorkloadLogicalSectorsRead = prometheus.NewDesc(
+		"smartctl_device_farm_workload_logical_sectors_read_total",
+		"Seagate FARM logical sectors read",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmWorkloadLogicalSectorsWritten = prometheus.NewDesc(
+		"smartctl_device_farm_workload_logical_sectors_written_total",
+		"Seagate FARM logical sectors written",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorUnrecoverableRead = prometheus.NewDesc(
+		"smartctl_device_farm_error_unrecoverable_read_total",
+		"Seagate FARM unrecoverable read errors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorUnrecoverableWrite = prometheus.NewDesc(
+		"smartctl_device_farm_error_unrecoverable_write_total",
+		"Seagate FARM unrecoverable write errors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorReallocatedSectors = prometheus.NewDesc(
+		"smartctl_device_farm_error_reallocated_sectors",
+		"Seagate FARM reallocated sectors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorReallocatedCandidates = prometheus.NewDesc(
+		"smartctl_device_farm_error_reallocated_candidate_sectors",
+		"Seagate FARM reallocated candidate sectors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorCRCErrors = prometheus.NewDesc(
+		"smartctl_device_farm_error_crc_errors_total",
+		"Seagate FARM total CRC errors",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorCommandTimeouts = prometheus.NewDesc(
+		"smartctl_device_farm_error_command_timeouts_total",
+		"Seagate FARM command timeout count",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmEnvironmentTemperature = prometheus.NewDesc(
+		"smartctl_device_farm_environment_temperature_celsius",
+		"Seagate FARM environment temperature",
+		[]string{"device", "temperature_type"},
+		nil,
+	)
+	metricFarmEnvironmentHumidity = prometheus.NewDesc(
+		"smartctl_device_farm_environment_humidity_percent",
+		"Seagate FARM environment humidity percentage",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmEnvironment12V = prometheus.NewDesc(
+		"smartctl_device_farm_environment_12v_millivolts",
+		"Seagate FARM 12V rail millivolts",
+		[]string{"device", "voltage_type"},
+		nil,
+	)
+	metricFarmEnvironment5V = prometheus.NewDesc(
+		"smartctl_device_farm_environment_5v_millivolts",
+		"Seagate FARM 5V rail millivolts",
+		[]string{"device", "voltage_type"},
+		nil,
+	)
+	metricFarmEnvironmentMotorPower = prometheus.NewDesc(
+		"smartctl_device_farm_environment_motor_power",
+		"Seagate FARM current motor power",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmReliabilityErrorRate = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_error_rate_raw",
+		"Seagate FARM error rate raw value",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmReliabilitySeekErrorRate = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_seek_error_rate_raw",
+		"Seagate FARM seek error rate raw value",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmReliabilityHighPriorityUnloads = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_high_priority_unload_events",
+		"Seagate FARM high priority unload events",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmReliabilityHeliumPressureTrip = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_helium_pressure_trip",
+		"Seagate FARM helium pressure trip count",
+		[]string{"device"},
+		nil,
+	)
+	metricFarmErrorUnrecoverableByHead = prometheus.NewDesc(
+		"smartctl_device_farm_error_unrecoverable_by_head",
+		"Seagate FARM per-head unrecoverable errors",
+		[]string{"device", "head", "error_type"},
+		nil,
+	)
+	metricFarmReliabilityReallocatedByHead = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_reallocated_sectors_by_head",
+		"Seagate FARM per-head reallocated sectors",
+		[]string{"device", "head"},
+		nil,
+	)
+	metricFarmReliabilityCandidatesByHead = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_reallocation_candidates_by_head",
+		"Seagate FARM per-head reallocation candidate sectors",
+		[]string{"device", "head"},
+		nil,
+	)
+	metricFarmReliabilitySkipWriteByHead = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_skip_write_detect_by_head",
+		"Seagate FARM per-head skip write detect count",
+		[]string{"device", "head", "detect_type"},
+		nil,
+	)
+	metricFarmReliabilityMRHeadResistanceByHead = prometheus.NewDesc(
+		"smartctl_device_farm_reliability_mr_head_resistance_by_head",
+		"Seagate FARM per-head MR head resistance",
+		[]string{"device", "head"},
+		nil,
+	)
 )

--- a/readjson.go
+++ b/readjson.go
@@ -64,7 +64,11 @@ func readFakeSMARTctl(logger *slog.Logger, device Device) gjson.Result {
 func readSMARTctl(logger *slog.Logger, device Device, wg *sync.WaitGroup) {
 	defer wg.Done()
 	start := time.Now()
-	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=" + *smartctlPowerModeCheck, "--format=brief", "--log=error", "--device=" + device.Type, device.Name}
+	var smartctlArgs = []string{"--json", "--info", "--health", "--attributes", "--tolerance=verypermissive", "--nocheck=" + *smartctlPowerModeCheck, "--format=brief", "--log=error"}
+	if *smartctlFarmLog {
+		smartctlArgs = append(smartctlArgs, "--log=farm")
+	}
+	smartctlArgs = append(smartctlArgs, "--device="+device.Type, device.Name)
 
 	logger.Debug("Calling smartctl with args", "args", strings.Join(smartctlArgs, " "))
 	out, err := exec.Command(*smartctlPath, smartctlArgs...).Output()
@@ -78,6 +82,10 @@ func readSMARTctl(logger *slog.Logger, device Device, wg *sync.WaitGroup) {
 	jsonOk := jsonIsOk(logger, json)
 	logger.Debug("Collected S.M.A.R.T. json data", "device", device, "duration", time.Since(start))
 	if rcOk && jsonOk {
+		if json.Get("device.name").String() == "" {
+			logger.Warn("Smartctl returned no device info, skipping cache", "device", device)
+			return
+		}
 		jsonCache.Store(device, JSONCache{JSON: json, LastCollect: time.Now()})
 	}
 }
@@ -110,11 +118,17 @@ func refreshAllDevices(logger *slog.Logger, devices []Device) {
 	}
 
 	var wg sync.WaitGroup
+	// Limit concurrent smartctl calls to avoid overwhelming the system
+	sem := make(chan struct{}, 8)
 	for _, device := range devices {
 		cacheValue, cacheOk := jsonCache.Load(device)
 		if !cacheOk || time.Now().After(cacheValue.(JSONCache).LastCollect.Add(*smartctlInterval)) {
 			wg.Add(1)
-			go readSMARTctl(logger, device, &wg)
+			sem <- struct{}{}
+			go func(d Device) {
+				defer func() { <-sem }()
+				readSMARTctl(logger, d, &wg)
+			}(device)
 		}
 	}
 	wg.Wait()
@@ -139,8 +153,15 @@ func resultCodeIsOk(logger *slog.Logger, device Device, SMARTCtlResult int64) bo
 	if SMARTCtlResult > 0 {
 		b := SMARTCtlResult
 		if (b & 1) != 0 {
-			logger.Error("Command line did not parse", "device", device)
-			result = false
+			if *smartctlFarmLog {
+				// When --log=farm is enabled, bit 0 may be set because the device
+				// does not support FARM logs. Downgrade to warning since SMART data
+				// is still valid.
+				logger.Warn("Command line did not parse (possibly unsupported --log=farm)", "device", device)
+			} else {
+				logger.Error("Command line did not parse", "device", device)
+				result = false
+			}
 		}
 		if (b & (1 << 1)) != 0 {
 			logger.Error("Device open failed, device did not return an IDENTIFY DEVICE structure, or device is in a low-power mode", "device", device)
@@ -175,7 +196,17 @@ func jsonIsOk(logger *slog.Logger, json gjson.Result) bool {
 	if messages.Exists() {
 		for _, message := range messages.Array() {
 			if message.Get("severity").String() == "error" {
-				logger.Error(message.Get("string").String())
+				msgStr := message.Get("string").String()
+				// FARM log errors are non-fatal: the device may not support FARM
+				// but still has valid SMART data
+				if *smartctlFarmLog &&
+					(strings.Contains(msgStr, "FARM") ||
+						strings.Contains(msgStr, "INVALID ARGUMENT TO -l: farm") ||
+						strings.Contains(msgStr, "VALID ARGUMENTS ARE:")) {
+					logger.Warn("FARM log not available", "msg", msgStr)
+					continue
+				}
+				logger.Error(msgStr)
 				return false
 			}
 		}

--- a/smartctl.go
+++ b/smartctl.go
@@ -101,6 +101,7 @@ func (smart *SMARTctl) Collect() {
 	smart.mineDeviceSelfTestLog()
 	smart.mineDeviceERC()
 	smart.mineSmartStatus()
+	smart.mineFarmLog()
 
 	if smart.device.interface_ == "nvme" {
 		smart.mineNvmePercentageUsed()

--- a/testdata/sat-Seagate_Exos_X18-ST12000NM000J-farm.json
+++ b/testdata/sat-Seagate_Exos_X18-ST12000NM000J-farm.json
@@ -1,0 +1,410 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      5
+    ],
+    "pre_release": false,
+    "svn_revision": "5714",
+    "platform_info": "x86_64-linux-5.14.0-611.9.1.el9_7.x86_64",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "--json",
+      "--log=farm",
+      "/dev/sda"
+    ],
+    "drive_database_version": {
+      "string": "7.5/5706"
+    },
+    "exit_status": 0
+  },
+  "local_time": {
+    "time_t": 1779999109,
+    "asctime": "Thu May 28 17:11:49 2026 ADT"
+  },
+  "device": {
+    "name": "/dev/sda",
+    "info_name": "/dev/sda [SAT]",
+    "type": "sat",
+    "protocol": "ATA"
+  },
+  "serial_number": "ZJV0PMA6",
+  "model_name": "ST12000NM000J-2TV103",
+  "model_family": "Seagate Exos X18",
+  "seagate_farm_log": {
+    "page_0_log_header": {
+      "farm_log_version": [
+        2,
+        1
+      ],
+      "pages_supported": 6,
+      "log_size": 98304,
+      "page_size": 16384,
+      "heads_supported": 24,
+      "number_of_copies": 0,
+      "reason_for_frame_capture": 0
+    },
+    "page_1_drive_information": {
+      "serial_number": "ZJV0PMA6",
+      "world_wide_name": "0x5000c500b17b059f",
+      "device_interface": "SATA",
+      "device_capacity_in_sectors": 23437770752,
+      "physical_sector_size": 4096,
+      "logical_sector_size": 512,
+      "device_buffer_size": 268435456,
+      "number_of_heads": 16,
+      "form_factor": "3.5 inches",
+      "rotation_rate": 7200,
+      "firmware_rev": "SN02    ",
+      "poh": 31583,
+      "spoh": 452565969807,
+      "head_flight_hours": 452565954977,
+      "head_load_events": 23003,
+      "power_cycle_count": 114,
+      "reset_count": 663,
+      "spin_up_time": 11,
+      "time_to_ready": 0,
+      "time_held": 0,
+      "drive_recording_type": "UNKNOWN",
+      "max_number_for_reasign": 0,
+      "date_of_assembly": "",
+      "depopulation_head_mask": 0
+    },
+    "page_2_workload_statistics": {
+      "total_read_commands": 947966635,
+      "total_write_commands": 159262778,
+      "total_random_reads": 31745091,
+      "total_random_writes": 134590856,
+      "total_other_commands": 31931579,
+      "logical_sectors_written": 108391477992,
+      "logical_sectors_read": 465962064793,
+      "dither": 0,
+      "dither_random": 0,
+      "dither_sequential": 0,
+      "read_commands_by_radius_0_3": 0,
+      "read_commands_by_radius_3_25": 0,
+      "read_commands_by_radius_25_75": 0,
+      "read_commands_by_radius_75_100": 0,
+      "write_commands_by_radius_0_3": 0,
+      "write_commands_by_radius_3_25": 0,
+      "write_commands_by_radius_25_75": 0,
+      "write_commands_by_radius_75_100": 0
+    },
+    "page_3_error_statistics": {
+      "number_of_unrecoverable_read_errors": 0,
+      "number_of_unrecoverable_write_errors": 0,
+      "number_of_reallocated_sectors": 0,
+      "number_of_read_recovery_attempts": 0,
+      "number_of_mechanical_start_failures": 0,
+      "number_of_reallocated_candidate_sectors": 0,
+      "total_asr_events": 124,
+      "total_crc_errors": 36507,
+      "attr_spin_retry_count": 0,
+      "normal_spin_retry_count": 100,
+      "worst_spin_rretry_count": 100,
+      "number_of_ioedc_errors": 0,
+      "command_time_out_count_total": 76,
+      "command_time_out_over_5_seconds_count": 0,
+      "command_time_out_over_7_seconds_count": 0,
+      "total_flash_led": 0,
+      "index_flash_led": 0,
+      "uncorrectables": 0,
+      "cumulative_unrecoverable_read_erc": 0,
+      "total_flash_led_errors": 0,
+      "flash_led_event_0": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_7": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_6": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_5": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_4": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_3": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_2": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "flash_led_event_1": {
+        "timestamp_of_event": 0,
+        "event_information": 0,
+        "power_cycle_event": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_0": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_1": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_2": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_3": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_4": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_5": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_6": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_7": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_8": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_9": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_10": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_11": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_12": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_13": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_14": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      },
+      "cum_lifetime_unrecoverable_by_head_15": {
+        "cum_lifetime_unrecoverable_read_repeating": 0,
+        "cum_lifetime_unrecoverable_read_unique": 0
+      }
+    },
+    "page_4_environment_statistics": {
+      "curent_temp": 25,
+      "highest_temp": 39,
+      "lowest_temp": 0,
+      "average_temp": 25,
+      "average_long_temp": 26,
+      "highest_short_temp": 38,
+      "lowest_short_temp": 15,
+      "highest_long_temp": 33,
+      "lowest_long_temp": 20,
+      "over_temp_time": 0,
+      "under_temp_time": 210,
+      "max_temp": 60,
+      "min_temp": 5,
+      "humidity": 120,
+      "current_motor_power": 3615,
+      "current_12v_in_mv": 0,
+      "minimum_12v_in_mv": 0,
+      "maximum_12v_in_mv": 0,
+      "current_5v_in_mv": 0,
+      "minimum_5v_in_mv": 0,
+      "maximum_5v_in_mv": 0,
+      "average_12v_power": 0,
+      "minimum_12v_power": 0,
+      "maximum_12v_power": 0,
+      "average_5v_power": 0,
+      "minimum_5v_power": 0,
+      "maximum_5v_power": 0
+    },
+    "page_5_reliability_statistics": {
+      "attr_error_rate_raw": 96007328,
+      "error_rate_normalized": 80,
+      "error_rate_worst": 64,
+      "attr_seek_error_rate_raw": 407955248,
+      "seek_error_rate_normalized": 86,
+      "seek_error_rate_worst": 60,
+      "high_priority_unload_events": 224,
+      "helium_presure_trip": 0,
+      "lbas_corrected_by_parity_sector": 0,
+      "dvga_skip_write_detect_by_head_0": 0,
+      "dvga_skip_write_detect_by_head_1": 0,
+      "dvga_skip_write_detect_by_head_2": 0,
+      "dvga_skip_write_detect_by_head_3": 0,
+      "dvga_skip_write_detect_by_head_4": 0,
+      "dvga_skip_write_detect_by_head_5": 0,
+      "dvga_skip_write_detect_by_head_6": 0,
+      "dvga_skip_write_detect_by_head_7": 0,
+      "dvga_skip_write_detect_by_head_8": 0,
+      "dvga_skip_write_detect_by_head_9": 0,
+      "dvga_skip_write_detect_by_head_10": 0,
+      "dvga_skip_write_detect_by_head_11": 0,
+      "dvga_skip_write_detect_by_head_12": 0,
+      "dvga_skip_write_detect_by_head_13": 0,
+      "dvga_skip_write_detect_by_head_14": 0,
+      "dvga_skip_write_detect_by_head_15": 0,
+      "rvga_skip_write_detect_by_head_0": 0,
+      "rvga_skip_write_detect_by_head_1": 0,
+      "rvga_skip_write_detect_by_head_2": 0,
+      "rvga_skip_write_detect_by_head_3": 0,
+      "rvga_skip_write_detect_by_head_4": 0,
+      "rvga_skip_write_detect_by_head_5": 0,
+      "rvga_skip_write_detect_by_head_6": 0,
+      "rvga_skip_write_detect_by_head_7": 0,
+      "rvga_skip_write_detect_by_head_8": 0,
+      "rvga_skip_write_detect_by_head_9": 0,
+      "rvga_skip_write_detect_by_head_10": 0,
+      "rvga_skip_write_detect_by_head_11": 0,
+      "rvga_skip_write_detect_by_head_12": 0,
+      "rvga_skip_write_detect_by_head_13": 0,
+      "rvga_skip_write_detect_by_head_14": 0,
+      "rvga_skip_write_detect_by_head_15": 0,
+      "fvga_skip_write_detect_by_head_0": 0,
+      "fvga_skip_write_detect_by_head_1": 0,
+      "fvga_skip_write_detect_by_head_2": 0,
+      "fvga_skip_write_detect_by_head_3": 0,
+      "fvga_skip_write_detect_by_head_4": 0,
+      "fvga_skip_write_detect_by_head_5": 0,
+      "fvga_skip_write_detect_by_head_6": 0,
+      "fvga_skip_write_detect_by_head_7": 0,
+      "fvga_skip_write_detect_by_head_8": 0,
+      "fvga_skip_write_detect_by_head_9": 0,
+      "fvga_skip_write_detect_by_head_10": 0,
+      "fvga_skip_write_detect_by_head_11": 0,
+      "fvga_skip_write_detect_by_head_12": 0,
+      "fvga_skip_write_detect_by_head_13": 0,
+      "fvga_skip_write_detect_by_head_14": 0,
+      "fvga_skip_write_detect_by_head_15": 0,
+      "skip_write_detect_threshold_exceeded_by_head_0": 0,
+      "skip_write_detect_threshold_exceeded_by_head_1": 0,
+      "skip_write_detect_threshold_exceeded_by_head_2": 0,
+      "skip_write_detect_threshold_exceeded_by_head_3": 0,
+      "skip_write_detect_threshold_exceeded_by_head_4": 0,
+      "skip_write_detect_threshold_exceeded_by_head_5": 0,
+      "skip_write_detect_threshold_exceeded_by_head_6": 0,
+      "skip_write_detect_threshold_exceeded_by_head_7": 0,
+      "skip_write_detect_threshold_exceeded_by_head_8": 0,
+      "skip_write_detect_threshold_exceeded_by_head_9": 0,
+      "skip_write_detect_threshold_exceeded_by_head_10": 0,
+      "skip_write_detect_threshold_exceeded_by_head_11": 0,
+      "skip_write_detect_threshold_exceeded_by_head_12": 0,
+      "skip_write_detect_threshold_exceeded_by_head_13": 0,
+      "skip_write_detect_threshold_exceeded_by_head_14": 0,
+      "skip_write_detect_threshold_exceeded_by_head_15": 0,
+      "write_workload_power_on_time_by_head_0": 0,
+      "write_workload_power_on_time_by_head_1": 0,
+      "write_workload_power_on_time_by_head_2": 0,
+      "write_workload_power_on_time_by_head_3": 0,
+      "write_workload_power_on_time_by_head_4": 0,
+      "write_workload_power_on_time_by_head_5": 0,
+      "write_workload_power_on_time_by_head_6": 0,
+      "write_workload_power_on_time_by_head_7": 0,
+      "write_workload_power_on_time_by_head_8": 0,
+      "write_workload_power_on_time_by_head_9": 0,
+      "write_workload_power_on_time_by_head_10": 0,
+      "write_workload_power_on_time_by_head_11": 0,
+      "write_workload_power_on_time_by_head_12": 0,
+      "write_workload_power_on_time_by_head_13": 0,
+      "write_workload_power_on_time_by_head_14": 0,
+      "write_workload_power_on_time_by_head_15": 0,
+      "mr_head_resistance_from_head_0": 452,
+      "mr_head_resistance_from_head_1": 373,
+      "mr_head_resistance_from_head_2": 443,
+      "mr_head_resistance_from_head_3": 375,
+      "mr_head_resistance_from_head_4": 356,
+      "mr_head_resistance_from_head_5": 348,
+      "mr_head_resistance_from_head_6": 415,
+      "mr_head_resistance_from_head_7": 417,
+      "mr_head_resistance_from_head_8": 407,
+      "mr_head_resistance_from_head_9": 606,
+      "mr_head_resistance_from_head_10": 370,
+      "mr_head_resistance_from_head_11": 444,
+      "mr_head_resistance_from_head_12": 475,
+      "mr_head_resistance_from_head_13": 404,
+      "mr_head_resistance_from_head_14": 550,
+      "mr_head_resistance_from_head_15": 439,
+      "second_mr_head_resistance_by_head_0": 0,
+      "second_mr_head_resistance_by_head_1": 0,
+      "second_mr_head_resistance_by_head_2": 0,
+      "second_mr_head_resistance_by_head_3": 0,
+      "second_mr_head_resistance_by_head_4": 0,
+      "second_mr_head_resistance_by_head_5": 0,
+      "second_mr_head_resistance_by_head_6": 0,
+      "second_mr_head_resistance_by_head_7": 0,
+      "second_mr_head_resistance_by_head_8": 0,
+      "second_mr_head_resistance_by_head_9": 0,
+      "second_mr_head_resistance_by_head_10": 0,
+      "second_mr_head_resistance_by_head_11": 0,
+      "second_mr_head_resistance_by_head_12": 0,
+      "second_mr_head_resistance_by_head_13": 0,
+      "second_mr_head_resistance_by_head_14": 0,
+      "second_mr_head_resistance_by_head_15": 0,
+      "number_of_reallocated_sectors_by_head_0": 0,
+      "number_of_reallocated_sectors_by_head_1": 0,
+      "number_of_reallocated_sectors_by_head_2": 0,
+      "number_of_reallocated_sectors_by_head_3": 0,
+      "number_of_reallocated_sectors_by_head_4": 0,
+      "number_of_reallocated_sectors_by_head_5": 0,
+      "number_of_reallocated_sectors_by_head_6": 0,
+      "number_of_reallocated_sectors_by_head_7": 0,
+      "number_of_reallocated_sectors_by_head_8": 0,
+      "number_of_reallocated_sectors_by_head_9": 0,
+      "number_of_reallocated_sectors_by_head_10": 0,
+      "number_of_reallocated_sectors_by_head_11": 0,
+      "number_of_reallocated_sectors_by_head_12": 0,
+      "number_of_reallocated_sectors_by_head_13": 0,
+      "number_of_reallocated_sectors_by_head_14": 0,
+      "number_of_reallocated_sectors_by_head_15": 0,
+      "number_of_reallocation_candidate_sectors_by_head_0": 0,
+      "number_of_reallocation_candidate_sectors_by_head_1": 0,
+      "number_of_reallocation_candidate_sectors_by_head_2": 0,
+      "number_of_reallocation_candidate_sectors_by_head_3": 0,
+      "number_of_reallocation_candidate_sectors_by_head_4": 0,
+      "number_of_reallocation_candidate_sectors_by_head_5": 0,
+      "number_of_reallocation_candidate_sectors_by_head_6": 0,
+      "number_of_reallocation_candidate_sectors_by_head_7": 0,
+      "number_of_reallocation_candidate_sectors_by_head_8": 0,
+      "number_of_reallocation_candidate_sectors_by_head_9": 0,
+      "number_of_reallocation_candidate_sectors_by_head_10": 0,
+      "number_of_reallocation_candidate_sectors_by_head_11": 0,
+      "number_of_reallocation_candidate_sectors_by_head_12": 0,
+      "number_of_reallocation_candidate_sectors_by_head_13": 0,
+      "number_of_reallocation_candidate_sectors_by_head_14": 0,
+      "number_of_reallocation_candidate_sectors_by_head_15": 0
+    },
+    "supported": true
+  }
+}


### PR DESCRIPTION
This PR adds Seagate FARM (Field Accessible Reliability Metrics) log support to smartctl_exporter.

FARM Log Metrics

Parses Seagate FARM log data from smartctl -j --log=farm and exposes the following Prometheus metric families:

- Environment: temperature (current/min/max/highest), 12V and 5V rail voltage (current/min/max), motor power
- Workload: read/write command counters
- Error tracking: reallocated sectors, CRC errors, command timeouts, unrecoverable read/write errors
- Reliability: MR head resistance per head, reallocated sectors per head, error rate, seek error rate, high priority unload events

FARM log collection is enabled via the --smartctl.farm-log flag and handles errors gracefully with limited concurrency to avoid overloading storage controllers.