### PR TITLE
Add optional udev ID_VDEV device labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Flags:
       --smartctl.device-include=""
                                Regexp of devices to include in automatic scanning. (mutually exclusive to
                                device-exclude)
+      --smartctl.vdev-label    Use the udev ID_VDEV property as the device label when available
       --web.telemetry-path="/metrics"  
                                Path under which to expose metrics
       --web.systemd-socket     Use systemd socket activation listeners instead of port listeners (Linux only).
@@ -53,6 +54,17 @@ Flags:
       --log.format=logfmt      Output format of log messages. One of: [logfmt, json]
       --version                Show application version.
 ```
+
+  ### ZFS vdev labels
+
+  Use `--smartctl.vdev-label` to replace the normal device label, such as `sda`,
+  with the device's `ID_VDEV` udev property when available. This can expose a
+  stable physical slot or ZFS vdev label in metrics instead of a kernel-assigned
+  device name.
+
+  The exporter uses `udevadm` to query the property for both automatically
+  discovered and explicitly configured devices. If `udevadm` fails or the device
+  has no `ID_VDEV` property, the normal device label is retained.
 
 ## TLS and basic authentication
 

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func (i *SMARTctlManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		json := readData(i.logger, device)
 		if json.Exists() {
 			info.SetJSON(json)
-			smart := NewSMARTctl(i.logger, json, ch)
+			smart := NewSMARTctl(i.logger, json, ch, device)
 			smart.Collect()
 		}
 	}
@@ -87,7 +87,7 @@ func (i *SMARTctlManagerCollector) RescanForDevices() {
 		time.Sleep(*smartctlRescanInterval)
 		i.logger.Info("Rescanning for devices")
 		devices := scanDevices(i.logger)
-		devices = buildDevicesFromFlag(devices)
+		devices = buildDevicesFromFlag(i.logger, devices)
 		i.mutex.Lock()
 		i.Devices = devices
 		i.mutex.Unlock()
@@ -126,6 +126,9 @@ var (
 	smartctlPowerModeCheck = kingpin.Flag("smartctl.powermode-check",
 		"Whether or not to check powermode before fetching data",
 	).Default("standby").String()
+	smartctlVdevLabel = kingpin.Flag("smartctl.vdev-label",
+		"Use the udev ID_VDEV property as the device label when available",
+	).Default("false").Bool()
 )
 
 // scanDevices uses smartctl to gather the list of available devices.
@@ -148,19 +151,15 @@ func scanDevices(logger *slog.Logger) []Device {
 		if filter.ignored(deviceLabel) {
 			logger.Info("Ignoring device", "name", deviceLabel)
 		} else {
-			logger.Info("Found device", "name", deviceLabel)
-			device := Device{
-				Name:  deviceName,
-				Type:  deviceType,
-				Label: deviceLabel,
-			}
+			device := newDevice(logger, deviceName, deviceType)
+			logger.Info("Found device", "name", deviceLabel, "label", device.Label)
 			scanDeviceResult = append(scanDeviceResult, device)
 		}
 	}
 	return scanDeviceResult
 }
 
-func buildDevicesFromFlag(devices []Device) []Device {
+func buildDevicesFromFlag(logger *slog.Logger, devices []Device) []Device {
 	// TODO: deduplication?
 	for _, device := range *smartctlDevices {
 		deviceName, deviceType, _ := strings.Cut(device, ";")
@@ -168,11 +167,7 @@ func buildDevicesFromFlag(devices []Device) []Device {
 			deviceType = "auto"
 		}
 
-		devices = append(devices, Device{
-			Name:  deviceName,
-			Type:  deviceType,
-			Label: buildDeviceLabel(deviceName, deviceType),
-		})
+		devices = append(devices, newDevice(logger, deviceName, deviceType))
 	}
 	return devices
 }
@@ -218,7 +213,7 @@ func main() {
 
 	if len(*smartctlDevices) > 0 {
 		logger.Info("Devices specified", "devices", strings.Join(*smartctlDevices, ", "))
-		devices = buildDevicesFromFlag(devices)
+		devices = buildDevicesFromFlag(logger, devices)
 		logger.Info("Devices filtered", "count", len(devices))
 	}
 

--- a/smartctl.go
+++ b/smartctl.go
@@ -55,7 +55,7 @@ func buildDeviceLabel(inputName string, inputType string) string {
 }
 
 // NewSMARTctl is smartctl constructor
-func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Metric) SMARTctl {
+func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Metric, configuredDevice Device) SMARTctl {
 	var model_name string
 	if obj := json.Get("model_name"); obj.Exists() {
 		model_name = obj.String()
@@ -66,13 +66,17 @@ func NewSMARTctl(logger *slog.Logger, json gjson.Result, ch chan<- prometheus.Me
 	if model_name == "" {
 		model_name = "unknown"
 	}
+	deviceLabel := configuredDevice.Label
+	if deviceLabel == "" {
+		deviceLabel = buildDeviceLabel(json.Get("device.name").String(), json.Get("device.type").String())
+	}
 
 	return SMARTctl{
 		ch:     ch,
 		json:   json,
 		logger: logger,
 		device: SMARTDevice{
-			device:     buildDeviceLabel(json.Get("device.name").String(), json.Get("device.type").String()),
+			device:     deviceLabel,
 			serial:     strings.TrimSpace(json.Get("serial_number").String()),
 			family:     strings.TrimSpace(GetStringIfExists(json, "model_family", "unknown")),
 			model:      strings.TrimSpace(model_name),

--- a/vdev_label.go
+++ b/vdev_label.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log/slog"
+	"os/exec"
+	"strings"
+)
+
+func newDevice(logger *slog.Logger, name, deviceType string) Device {
+	return newDeviceWithVdevLookup(logger, name, deviceType, *smartctlVdevLabel, lookupVdevLabel)
+}
+
+func newDeviceWithVdevLookup(logger *slog.Logger, name, deviceType string, enabled bool, lookup func(string) (string, error)) Device {
+	device := Device{
+		Name:  name,
+		Type:  deviceType,
+		Label: buildDeviceLabel(name, deviceType),
+	}
+	if !enabled {
+		return device
+	}
+
+	label, err := lookup(name)
+	if err != nil {
+		logger.Debug("Unable to query udev properties", "device", name, "err", err)
+		return device
+	}
+	if label != "" {
+		device.Label = label
+		logger.Debug("Using ID_VDEV as device label", "device", name, "label", label)
+	}
+	return device
+}
+
+func lookupVdevLabel(name string) (string, error) {
+	output, err := exec.Command("udevadm", "info", "--query=property", name).Output()
+	if err != nil {
+		return "", err
+	}
+	return parseVdevLabel(string(output)), nil
+}
+
+func parseVdevLabel(output string) string {
+	for line := range strings.Lines(output) {
+		key, value, found := strings.Cut(strings.TrimSpace(line), "=")
+		if found && key == "ID_VDEV" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/vdev_label_test.go
+++ b/vdev_label_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tidwall/gjson"
+)
+
+func TestParseVdevLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected string
+	}{
+		{
+			name:     "ID_VDEV property",
+			output:   "DEVNAME=/dev/sda\nID_MODEL=ST12000NM000J\nID_VDEV=2-1\n",
+			expected: "2-1",
+		},
+		{
+			name:     "value containing equals",
+			output:   "ID_VDEV=pool=slot-1\n",
+			expected: "pool=slot-1",
+		},
+		{
+			name:     "empty property",
+			output:   "ID_VDEV=\n",
+			expected: "",
+		},
+		{
+			name:     "property absent",
+			output:   "DEVNAME=/dev/sda\nID_MODEL=ST12000NM000J\n",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual := parseVdevLabel(test.output); actual != test.expected {
+				t.Errorf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestNewDeviceWithoutVdevLabel(t *testing.T) {
+	device := newDeviceWithVdevLookup(slog.Default(), "/dev/bus/0", "megaraid,1", false, func(string) (string, error) {
+		t.Fatal("lookup called when VDEV labels are disabled")
+		return "", nil
+	})
+	if device.Label != "bus_0_megaraid_1" {
+		t.Errorf("expected default device label, got %q", device.Label)
+	}
+}
+
+func TestNewDeviceWithVdevLabel(t *testing.T) {
+	device := newDeviceWithVdevLookup(slog.Default(), "/dev/sda", "auto", true, func(name string) (string, error) {
+		if name != "/dev/sda" {
+			t.Errorf("expected lookup for /dev/sda, got %q", name)
+		}
+		return "2-1", nil
+	})
+	if device.Label != "2-1" {
+		t.Errorf("expected VDEV label, got %q", device.Label)
+	}
+}
+
+func TestNewDeviceVdevLabelFallback(t *testing.T) {
+	tests := []struct {
+		name   string
+		lookup func(string) (string, error)
+	}{
+		{
+			name: "property absent",
+			lookup: func(string) (string, error) {
+				return "", nil
+			},
+		},
+		{
+			name: "lookup error",
+			lookup: func(string) (string, error) {
+				return "", errors.New("udevadm unavailable")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			device := newDeviceWithVdevLookup(slog.Default(), "/dev/sda", "auto", true, test.lookup)
+			if device.Label != "sda" {
+				t.Errorf("expected default device label, got %q", device.Label)
+			}
+		})
+	}
+}
+
+func TestNewSMARTctlUsesConfiguredDeviceLabel(t *testing.T) {
+	json := gjson.Parse(`{
+		"device": {"name": "/dev/sda", "type": "sat", "protocol": "ATA"},
+		"model_name": "ST12000NM000J"
+	}`)
+	ch := make(chan prometheus.Metric)
+	device := Device{Name: "/dev/sda", Type: "sat", Label: "2-1"}
+
+	smart := NewSMARTctl(slog.Default(), json, ch, device)
+	if smart.device.device != "2-1" {
+		t.Errorf("expected configured device label, got %q", smart.device.device)
+	}
+}


### PR DESCRIPTION
vdev-label Support

Adds --smartctl.vdev-label flag that reads udev ID_VDEV properties to use ZFS vdev labels (e.g. enclosure slot identifiers) as the device label in metrics, making it easier to correlate metrics with physical disk locations.