### PR TITLE
Build arm64 docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM alpine:3
+FROM --platform=${OS}/${ARCH} alpine:3
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 RUN apk add smartmontools

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64
+DOCKER_ARCHS ?= amd64 arm64
 DOCKER_REPO  ?= prometheuscommunity
 
 include Makefile.common


### PR DESCRIPTION
Re-lands #150, which was reverted in #156 for a missing DCO sign-off, nothing technical. Fixes #105.

DOCKER_ARCHS alone isn't enough. Without `--platform` on the FROM the arm64 tag gets an amd64 alpine and an amd64 smartctl. #295, #366 and #368 are missing that, so they prolly dont fully work.

`--platform` should be the alpine equivalent of the `busybox-${OS}-${ARCH}` tags from #105.

I built both arches off the v0.14.0 release binaries, arm64 is fine. Not sure the release runners have binfmt for `apk add` on the non-native arch.